### PR TITLE
Use Pexels for placeholder images

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -240,15 +240,16 @@ const App: React.FC = () => {
     if (ttsPlaybackStatus !== 'idle') handleTTSStop();
   };
 
-  const handleAddScene = () => {
+  const handleAddScene = async () => {
     const newSceneId = `scene-new-${Date.now()}`;
+    const placeholder = await fetchPlaceholderFootageUrl(["new scene", "abstract"], aspectRatio, newSceneId);
     const newScene: Scene = {
       id: newSceneId,
       sceneText: "New scene text...",
       keywords: ["new scene"],
       imagePrompt: "Abstract background for a new scene",
       duration: 5,
-      footageUrl: fetchPlaceholderFootageUrl(["new scene", "abstract"], aspectRatio, newSceneId), // Default placeholder
+      footageUrl: placeholder,
       kenBurnsConfig: { targetScale: 1.1, targetXPercent: 0, targetYPercent: 0, originXRatio: 0.5, originYRatio: 0.5, animationDurationS: 5 }
     };
     setScenes(prevScenes => [...prevScenes, newScene]);
@@ -274,12 +275,12 @@ const App: React.FC = () => {
                 newFootageUrl = result.base64Image;
             } else {
                 addWarning(result.userFriendlyError || `AI image failed for scene ${sceneId}. Using new placeholder.`);
-                newFootageUrl = fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
+                newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
                 errorOccurred = true;
             }
         } else {
             setProgressValue(30);
-            newFootageUrl = fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
+            newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
         }
         
         setScenes(prevScenes => prevScenes.map(s =>

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. (Optional) Set the `PEXELS_API_KEY` in `.env.local` to enable higher-quality
+   placeholder images from Pexels.
+4. Run the app:
    `npm run dev`

--- a/constants.ts
+++ b/constants.ts
@@ -15,3 +15,4 @@ export const IMAGEN_MODEL = 'imagen-3.0-generate-002';
 
 // Placeholder for API Key - this should be set in the environment
 export const API_KEY = process.env.API_KEY;
+export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- support new `PEXELS_API_KEY` env variable
- fetch placeholder images from Pexels API instead of Picsum
- allow async placeholder retrieval in app
- document optional Pexels key

## Testing
- `npm install`
- `npm run build` *(fails: CallToolResultSchema is not exported)*
- `npx tsc --noEmit` *(reports missing types and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bb8a68170832e8c1b6a230ef5ddc4