### PR TITLE
Fix ffmpeg download by enabling cross origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This contains everything you need to run your app locally.
 4. Run the app:
    `npm run dev`
 
+If video downloads fail during MP4 conversion, ensure your browser is served with cross-origin isolation headers. The included `index.html` now specifies `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` meta tags, which are required for ffmpeg.wasm.
+
 The generated video will now download as an MP4 file.
 
 ### Faster MP4 conversion

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Narrative Video Automator</title>
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+    <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       /* Custom scrollbar for a more modern look */


### PR DESCRIPTION
## Summary
- enable cross-origin isolation in `index.html` so ffmpeg.wasm can run
- document new requirement in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bfe28f38c832e803220540ccb7348