### PR TITLE
Fix cross-origin isolation for ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This contains everything you need to run your app locally.
 4. Run the app:
    `npm run dev`
 
-If video downloads fail during MP4 conversion, ensure your browser is served with cross-origin isolation headers. The included `index.html` now specifies `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` meta tags, which are required for ffmpeg.wasm.
+Video downloads require the browser to be cross-origin isolated so that ffmpeg.wasm can use `SharedArrayBuffer`. The development server now automatically sends the necessary `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers. Make sure you access the app via `npm run dev` (or `npm run preview` after building) rather than opening `index.html` directly.
 
 The generated video will now download as an MP4 file.
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,18 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, '.'),
         }
+      },
+      server: {
+        headers: {
+          'Cross-Origin-Opener-Policy': 'same-origin',
+          'Cross-Origin-Embedder-Policy': 'require-corp'
+        }
+      },
+      preview: {
+        headers: {
+          'Cross-Origin-Opener-Policy': 'same-origin',
+          'Cross-Origin-Embedder-Policy': 'require-corp'
+        }
       }
     };
 });


### PR DESCRIPTION
## Summary
- configure Vite dev and preview servers to send COOP/COEP headers
- clarify README with cross-origin instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c0821955c832ebf8339e4da0959d9