### PR TITLE
Update placeholder image source to fix CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This contains everything you need to run your app locally.
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. (Optional) Set the `PEXELS_API_KEY` in `.env.local` to enable higher-quality
-   placeholder images from Pexels.
+   placeholder images from Pexels. If this key is not provided, the app falls
+   back to using images from [loremflickr](https://loremflickr.com/), which
+   includes CORS headers to avoid browser errors.
    Placeholder images are now requested at a smaller resolution (960x540 or
-   540x960) to speed up the preview and avoid long preload times.
-   If an image fails to load during rendering, the app now substitutes a small
-   fallback image so video generation can continue rather than stalling.
+   540x960) to speed up the preview and avoid long preload times. If an image
+   fails to load during rendering, the app substitutes a small fallback image so
+   video generation can continue rather than stalling.
 4. Run the app:
    `npm run dev`
 

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -58,14 +58,11 @@ export const fetchPlaceholderFootageUrl = async (
       console.warn('Error fetching from Pexels API:', err);
     }
   } else {
-    console.warn('PEXELS_API_KEY not set. Falling back to Picsum.');
+    console.warn('PEXELS_API_KEY not set. Falling back to loremflickr.');
   }
 
-  let seed = query.replace(/\s+/g, '-').toLowerCase();
-  if (sceneId) {
-    seed = `${seed}-${sceneId.substring(0,5)}`;
-  }
-  return `https://picsum.photos/seed/${seed}/${width}/${height}?random_bust=${Date.now()}`;
+  const encodedQuery = encodeURIComponent(query);
+  return `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`;
 };
 
 export interface ProcessNarrationOptions {


### PR DESCRIPTION
## Summary
- use loremflickr for placeholder images when no PEXELS_API_KEY is configured
- mention new placeholder fallback in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c10933430832e9ebc0b4591282fc8