### PR TITLE
Add navbar and unify branding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,8 +13,13 @@ import { processNarrationToScenes, fetchPlaceholderFootageUrl } from './services
 import { generateWebMFromScenes } from './services/videoRenderingService.ts';
 import { convertWebMToMP4 } from './services/mp4ConversionService.ts';
 import { SparklesIcon } from './components/IconComponents.tsx';
+import Navbar from './components/Navbar.tsx';
 
-const App: React.FC = () => {
+interface AppProps {
+  onGoHome: () => void;
+}
+
+const App: React.FC<AppProps> = ({ onGoHome }) => {
   const [narrationText, setNarrationText] = useState<string>('');
   const [scenes, setScenes] = useState<Scene[]>([]);
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>(DEFAULT_ASPECT_RATIO);
@@ -326,10 +331,11 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-100 flex flex-col items-center p-4 sm:p-6 lg:p-8">
+      <Navbar rightButtonText="Home" onRightButtonClick={onGoHome} />
       <header className="mb-6 sm:mb-8 text-center">
         <div className="flex items-center justify-center space-x-3">
-           <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-teal-400" />
-           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight bg-gradient-to-r from-teal-300 via-teal-400 to-cyan-400 text-transparent bg-clip-text">
+           <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-fuchsia-400" />
+           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight bg-gradient-to-r from-fuchsia-300 via-fuchsia-400 to-purple-400 text-transparent bg-clip-text">
              {APP_TITLE}
            </h1>
         </div>
@@ -346,8 +352,8 @@ const App: React.FC = () => {
 
       <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
-            <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-300">1. Enter Your Narration</h2>
+          <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl border border-fuchsia-700/30">
+            <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400">1. Enter Your Narration</h2>
             <TextInputArea
               value={narrationText}
               onChange={setNarrationText}
@@ -355,8 +361,8 @@ const App: React.FC = () => {
               disabled={isGeneratingScenes || apiKeyMissing || isRenderingVideo}
             />
           </div>
-          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
-             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-300">2. Configure & Generate</h2>
+          <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl border border-fuchsia-700/30">
+             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400">2. Configure & Generate</h2>
             <Controls
               aspectRatio={aspectRatio}
               onAspectRatioChange={(ratio) => {
@@ -381,8 +387,8 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        <div className="lg:col-span-2 bg-gray-800 p-1 sm:p-2 rounded-xl shadow-2xl">
-           <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-teal-300 px-3 py-2">3. Preview Your Video</h2>
+        <div className="lg:col-span-2 bg-gradient-to-br from-gray-800 to-gray-900 p-1 sm:p-2 rounded-xl shadow-2xl border border-fuchsia-700/30">
+           <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-fuchsia-400 px-3 py-2">3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}
             aspectRatio={aspectRatio}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -39,7 +39,7 @@ const Controls: React.FC<ControlsProps> = ({
   const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
 
   return (
-    <div className="p-4 bg-gray-800 rounded-lg shadow-lg space-y-6">
+    <div className="p-4 bg-gradient-to-br from-gray-800 to-gray-900 border border-fuchsia-700/30 rounded-lg shadow-lg space-y-6">
       <div>
         <label className="block text-sm font-medium text-gray-300 mb-2">Aspect Ratio</label>
         <div className="flex space-x-2">
@@ -49,8 +49,8 @@ const Controls: React.FC<ControlsProps> = ({
               type="button"
               onClick={() => onAspectRatioChange(ratio)}
               disabled={isGenerating}
-              className={`flex-1 p-3 rounded-md text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-teal-500
-                ${aspectRatio === ratio ? 'bg-teal-600 text-white shadow-md' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}
+              className={`flex-1 p-3 rounded-md text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-fuchsia-500
+                ${aspectRatio === ratio ? 'bg-fuchsia-600 text-white shadow-md' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}
                 ${isGenerating ? 'opacity-50 cursor-not-allowed' : ''}`}
               aria-pressed={aspectRatio === ratio}
             >
@@ -71,7 +71,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={useAiImages}
             onChange={(e) => onUseAiImagesChange(e.target.checked)}
             disabled={isGenerating || apiKeyMissing}
-            className="h-4 w-4 text-teal-600 border-gray-600 rounded focus:ring-teal-500 bg-gray-700 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
           />
           Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
         </label>
@@ -85,7 +85,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={includeSubtitlesOnDownload}
             onChange={(e) => onIncludeSubtitlesChange(e.target.checked)}
             disabled={isGenerating}
-            className="h-4 w-4 text-teal-600 border-gray-600 rounded focus:ring-teal-500 bg-gray-700 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
           />
           Include subtitles in download
         </label>
@@ -99,7 +99,7 @@ const Controls: React.FC<ControlsProps> = ({
               checked={isTTSEnabled}
               onChange={(e) => onTTSEnabledChange(e.target.checked)}
               disabled={isGenerating}
-              className="h-4 w-4 text-teal-600 border-gray-600 rounded focus:ring-teal-500 bg-gray-700 mr-2 disabled:opacity-50"
+              className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
             />
             Enable TTS Narration (Preview)
           </label>
@@ -110,7 +110,7 @@ const Controls: React.FC<ControlsProps> = ({
         onClick={onGenerate}
         disabled={!canGenerate}
         className={`w-full flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white
-                  ${!canGenerate ? 'bg-gray-600 cursor-not-allowed' : 'bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-teal-500'}
+                  ${!canGenerate ? 'bg-gray-600 cursor-not-allowed' : 'bg-fuchsia-600 hover:bg-fuchsia-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-fuchsia-500'}
                   transition-colors duration-150`}
         aria-live="polite"
         title={apiKeyMissing ? "API Key is missing. Cannot generate." : (narrationText.trim() === '' ? "Please enter narration text." : (hasScenes ? "Re-analyze narration & generate new scenes" : "Generate Video"))}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SparklesIcon } from './IconComponents.tsx';
+import Navbar from './Navbar.tsx';
 
 interface LandingPageProps {
   onGetStarted: () => void;
@@ -8,15 +9,7 @@ interface LandingPageProps {
 const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
   return (
     <div className="min-h-screen flex flex-col bg-black text-white">
-      <header className="p-6 flex justify-between items-center">
-        <h1 className="text-3xl font-bold text-fuchsia-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
-        <button
-          className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
-          onClick={onGetStarted}
-        >
-          Launch App
-        </button>
-      </header>
+      <Navbar rightButtonText="Launch App" onRightButtonClick={onGetStarted} />
       <main className="flex-1 flex flex-col items-center justify-center text-center px-4">
         <h2 className="text-4xl sm:text-6xl font-extrabold mb-6">
           Your Marketing Video Sidekick

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { SparklesIcon } from './IconComponents.tsx';
+
+interface NavbarProps {
+  brand?: string;
+  rightButtonText?: string;
+  onRightButtonClick?: () => void;
+}
+
+const Navbar: React.FC<NavbarProps> = ({
+  brand = 'CineSynth',
+  rightButtonText,
+  onRightButtonClick,
+}) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <nav className="bg-black text-white border-b border-gray-800">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between h-16 items-center">
+          <div className="flex items-center">
+            <SparklesIcon className="w-6 h-6 text-fuchsia-400 mr-2" />
+            <span className="font-bold text-xl" style={{ fontFamily: 'Fira Code' }}>{brand}</span>
+          </div>
+          <div className="flex items-center">
+            {rightButtonText && (
+              <button
+                onClick={onRightButtonClick}
+                className="hidden sm:inline-flex bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow"
+              >
+                {rightButtonText}
+              </button>
+            )}
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="sm:hidden inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-fuchsia-500 ml-2"
+            >
+              <span className="sr-only">Open main menu</span>
+              <svg
+                className="block h-6 w-6"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d={menuOpen ? 'M6 18L18 6M6 6l12 12' : 'M3.75 5.25h16.5m-16.5 6h16.5m-16.5 6h16.5'}
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        {rightButtonText && menuOpen && (
+          <div className="sm:hidden pb-3">
+            <button
+              onClick={onRightButtonClick}
+              className="block w-full text-left px-3 py-2 rounded-md text-base font-medium bg-fuchsia-600 hover:bg-fuchsia-500"
+            >
+              {rightButtonText}
+            </button>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -12,7 +12,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ progress, message }) => {
       {message && <p className="text-sm text-gray-400 mb-1 text-center">{message}</p>}
       <div className="w-full bg-gray-700 rounded-full h-2.5">
         <div
-          className="bg-teal-500 h-2.5 rounded-full transition-all duration-300 ease-out"
+          className="bg-fuchsia-500 h-2.5 rounded-full transition-all duration-300 ease-out"
           style={{ width: `${progress}%` }}
         ></div>
       </div>

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -56,13 +56,13 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
 
 
   return (
-    <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
-      <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-teal-300">4. Edit Scenes</h3>
+    <div className="bg-gradient-to-br from-gray-800 to-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl border border-fuchsia-700/30">
+      <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400">4. Edit Scenes</h3>
       {scenes.length === 0 && <p className="text-gray-400">No scenes generated yet. Use Step 1 & 2.</p>}
       <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
         {scenes.map((scene, index) => (
-          <div key={scene.id} className="bg-gray-700 p-4 rounded-lg shadow-md">
-            <h4 className="font-semibold text-teal-400 mb-2">Scene {index + 1}</h4>
+          <div key={scene.id} className="bg-gray-700/60 p-4 rounded-lg shadow-md border border-fuchsia-700/20">
+          <h4 className="font-semibold text-fuchsia-400 mb-2">Scene {index + 1}</h4>
             {editableSceneId === scene.id ? (
               <div className="space-y-3">
                 <div>
@@ -72,7 +72,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editText}
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
-                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-teal-500 focus:border-teal-500"
+                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -84,7 +84,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editDuration}
                     onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
                     min="1"
-                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-teal-500 focus:border-teal-500"
+                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -92,7 +92,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                   <button
                     onClick={() => handleSave(scene.id)}
                     disabled={isGenerating}
-                    className="px-3 py-1.5 text-sm bg-teal-600 hover:bg-teal-700 rounded-md text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-sm bg-fuchsia-600 hover:bg-fuchsia-700 rounded-md text-white disabled:opacity-50"
                   >
                     Save Changes
                   </button>
@@ -125,14 +125,14 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                   <button
                     onClick={() => handleEdit(scene)}
                     disabled={isGenerating || isUpdatingImage === scene.id}
-                    className="px-3 py-1.5 text-xs bg-teal-600 hover:bg-teal-700 rounded-md text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-xs bg-fuchsia-600 hover:bg-fuchsia-700 rounded-md text-white disabled:opacity-50"
                   >
                     Edit Scene
                   </button>
                   <button
                     onClick={() => handleImageUpdate(scene.id)}
                     disabled={isGenerating || apiKeyMissing || isUpdatingImage === scene.id}
-                    className="px-3 py-1.5 text-xs bg-teal-600 hover:bg-teal-700 rounded-md text-white disabled:opacity-50 flex items-center"
+                    className="px-3 py-1.5 text-xs bg-fuchsia-600 hover:bg-fuchsia-700 rounded-md text-white disabled:opacity-50 flex items-center"
                     title={apiKeyMissing && useAiImagesGlobal ? "API Key missing, cannot generate AI image" : (useAiImagesGlobal ? "Refresh AI Image" : "Refresh Placeholder")}
                   >
                      {isUpdatingImage === scene.id ? (
@@ -158,7 +158,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
       <button
         onClick={onAddScene}
         disabled={isGenerating}
-        className="mt-6 w-full px-4 py-2 bg-teal-600 hover:bg-teal-700 rounded-md text-white font-medium disabled:opacity-50"
+        className="mt-6 w-full px-4 py-2 bg-fuchsia-600 hover:bg-fuchsia-700 rounded-md text-white font-medium disabled:opacity-50"
       >
         Add New Scene
       </button>

--- a/components/TextInputArea.tsx
+++ b/components/TextInputArea.tsx
@@ -16,7 +16,7 @@ const TextInputArea: React.FC<TextInputAreaProps> = ({ value, onChange, placehol
       placeholder={placeholder || "Enter your narration here..."}
       disabled={disabled}
       rows={8}
-      className="w-full p-4 bg-gray-800 border border-gray-700 rounded-lg shadow-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
+      className="w-full p-4 bg-gray-800 border border-gray-700 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
     />
   );
 };

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -279,7 +279,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   if (isGenerating && scenes.length === 0) {
      return (
       <div className={`w-full bg-gray-800 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-teal-500 mb-4"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-500 mb-4"></div>
         <p>Generating scenes & visuals...</p>
       </div>
     );
@@ -303,12 +303,12 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           ) : null
         ))}
         {currentScene && isPlaying && (
-            <div className="absolute top-0 left-0 h-1 bg-teal-600 transition-all duration-100 ease-linear" style={{ width: `${(elapsedTime / ((currentScene?.duration || 1) * 1000)) * 100}%` }}></div>
+            <div className="absolute top-0 left-0 h-1 bg-fuchsia-600 transition-all duration-100 ease-linear" style={{ width: `${(elapsedTime / ((currentScene?.duration || 1) * 1000)) * 100}%` }}></div>
         )}
       </div>
       {scenes.length > 0 && (
         <div className="mt-2 h-2 bg-gray-700 rounded-full overflow-hidden">
-          <div className="h-full bg-teal-500" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
+          <div className="h-full bg-fuchsia-500" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
         </div>
       )}
       <div className="mt-3 flex items-center justify-between space-x-2">
@@ -316,7 +316,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           <button
             onClick={handlePlayPause}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-teal-400 hover:text-teal-300"
+            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-fuchsia-400 hover:text-fuchsia-300"
             aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isPlaying ? <PauseIcon className="w-5 h-5 sm:w-6 sm:h-6" /> : <PlayIcon className="w-5 h-5 sm:w-6 sm:h-6" />}
@@ -324,7 +324,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
            <button
             onClick={handleRestart}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-sm text-teal-400 hover:text-teal-300"
+            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-sm text-fuchsia-400 hover:text-fuchsia-300"
             aria-label="Restart"
           >
             Restart
@@ -339,7 +339,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
         <button
           onClick={onDownloadRequest}
           disabled={scenes.length === 0 || isGenerating || isDownloading}
-          className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-teal-600 hover:bg-teal-700 disabled:opacity-50 text-white text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
+          className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-fuchsia-600 hover:bg-fuchsia-700 disabled:opacity-50 text-white text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
           aria-live="polite"
         >
           <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />

--- a/index.tsx
+++ b/index.tsx
@@ -5,7 +5,11 @@ import LandingPage from './components/LandingPage.tsx';
 
 const Root: React.FC = () => {
   const [started, setStarted] = useState(false);
-  return started ? <App /> : <LandingPage onGetStarted={() => setStarted(true)} />;
+  return started ? (
+    <App onGoHome={() => setStarted(false)} />
+  ) : (
+    <LandingPage onGetStarted={() => setStarted(true)} />
+  );
 };
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
## Summary
- introduce shared `Navbar` component with mobile toggle
- update landing page and app to use new navbar
- switch UI accent color from teal to fuchsia
- tweak card backgrounds and progress bar colors
- connect landing page and app via props

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f0c594100832e8db85fb5a923341e