### PR TITLE
Enhance landing UI and dark theme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -350,7 +350,7 @@ const App: React.FC = () => {
 
       <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>1. Enter Your Narration</h2>
             <TextInputArea
               value={narrationText}
@@ -359,7 +359,7 @@ const App: React.FC = () => {
               disabled={isGeneratingScenes || apiKeyMissing || isRenderingVideo}
             />
           </div>
-          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
              <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>2. Configure & Generate</h2>
             <Controls
               aspectRatio={aspectRatio}
@@ -385,7 +385,7 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        <div className="lg:col-span-2 bg-gray-800 p-1 sm:p-2 rounded-xl shadow-2xl">
+        <div className="lg:col-span-2 bg-gray-900 p-1 sm:p-2 rounded-xl shadow-2xl">
            <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-fuchsia-400 px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -39,7 +39,7 @@ const Controls: React.FC<ControlsProps> = ({
   const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
 
   return (
-    <div className="p-4 bg-gray-800 rounded-lg shadow-lg space-y-6">
+    <div className="p-4 bg-gray-900 rounded-lg shadow-lg space-y-6">
       <div>
         <label className="block text-sm font-medium text-gray-300 mb-2">Aspect Ratio</label>
         <div className="flex space-x-2">
@@ -50,7 +50,7 @@ const Controls: React.FC<ControlsProps> = ({
               onClick={() => onAspectRatioChange(ratio)}
               disabled={isGenerating}
               className={`flex-1 p-3 rounded-md text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-fuchsia-500
-                ${aspectRatio === ratio ? 'bg-fuchsia-600 text-white shadow-md' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'}
+                ${aspectRatio === ratio ? 'bg-fuchsia-600 text-white shadow-md' : 'bg-gray-800 text-gray-300 hover:bg-gray-700'}
                 ${isGenerating ? 'opacity-50 cursor-not-allowed' : ''}`}
               aria-pressed={aspectRatio === ratio}
             >
@@ -71,7 +71,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={useAiImages}
             onChange={(e) => onUseAiImagesChange(e.target.checked)}
             disabled={isGenerating || apiKeyMissing}
-            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
           />
           Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
         </label>
@@ -85,7 +85,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={includeSubtitlesOnDownload}
             onChange={(e) => onIncludeSubtitlesChange(e.target.checked)}
             disabled={isGenerating}
-            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
           />
           Include subtitles in download
         </label>
@@ -99,7 +99,7 @@ const Controls: React.FC<ControlsProps> = ({
               checked={isTTSEnabled}
               onChange={(e) => onTTSEnabledChange(e.target.checked)}
               disabled={isGenerating}
-              className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-700 mr-2 disabled:opacity-50"
+              className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
             />
             Enable TTS Narration (Preview)
           </label>

--- a/components/IconComponents.tsx
+++ b/components/IconComponents.tsx
@@ -36,3 +36,34 @@ export const SparklesIcon: React.FC<{ className?: string }> = ({ className }) =>
     <path strokeLinecap="round" strokeLinejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L1.25 9l2.846-.813a4.5 4.5 0 003.09-3.09L9 1.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 9l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.25 10.5l1.562-1.563a1.875 1.875 0 00-2.652-2.652L15.75 7.5a1.875 1.875 0 002.5 3zm-3.75 2.25l1.563-1.562a1.875 1.875 0 00-2.652-2.652L10.5 12.75a1.875 1.875 0 002.5 3.001z" />
   </svg>
 );
+
+export const MenuIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M4 6H20M4 12H20M4 18H20" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const CloseIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M6 18L18 6M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const TrendingUpIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M13 7h8v8M21 7l-8 8-4-4-6 6" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const ScissorsIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M14.121 14.121L19 19M12 12l7-7M12 12l-2.879 2.879M12 12L9.121 9.121M9.121 14.879A3 3 0 1 1 7 14a3 3 0 0 1 2.121.879ZM9.121 9.121A3 3 0 1 0 7 10a3 3 0 0 0 2.121-.879Z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const FireIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M17.657 18.657A7.5 7.5 0 0 1 6.343 18.657C4.781 17.095 4 15.047 4 13c0-2.048.781-4.095 2.343-5.657 0 0 .657 1.657 2.657 2.657 0-2 0.5-5 2.986-7 2 2 2.778 3.778 4.343 5.343A7.5 7.5 0 0 1 20 13c0 2.047-.781 4.095-2.343 5.657Z" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M9.879 16.121a3 3 0 0 0 4.242 0c.586-.586.879-1.354.879-2.121s-.293-1.535-.879-2.121C13.539 11.296 12.778 11 12 11v3l-2 .001c0 .768.293 1.536.879 2.12Z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,21 +1,44 @@
-import React from 'react';
-import { SparklesIcon } from './IconComponents.tsx';
+import React, { useState } from 'react';
+import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon } from './IconComponents.tsx';
 
 interface LandingPageProps {
   onGetStarted: () => void;
 }
 
 const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <div className="min-h-screen flex flex-col bg-black text-white">
-      <header className="p-6 flex justify-between items-center">
-        <h1 className="text-3xl font-bold text-fuchsia-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
-        <button
-          className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
-          onClick={onGetStarted}
-        >
-          Launch App
-        </button>
+      <header className="bg-black/70 backdrop-blur sticky top-0 z-10">
+        <nav className="max-w-6xl mx-auto flex justify-between items-center p-4">
+          <h1 className="text-3xl font-bold text-fuchsia-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
+          <div className="hidden sm:flex items-center gap-6">
+            <a href="#features" className="hover:text-fuchsia-400 transition-colors">Features</a>
+            <button
+              className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
+              onClick={onGetStarted}
+            >
+              Launch App
+            </button>
+          </div>
+          <button
+            className="sm:hidden p-2 rounded-md hover:bg-gray-900"
+            onClick={() => setMenuOpen(!menuOpen)}
+          >
+            {menuOpen ? <CloseIcon className="w-6 h-6" /> : <MenuIcon className="w-6 h-6" />}
+          </button>
+        </nav>
+        {menuOpen && (
+          <div className="sm:hidden px-4 pb-4 space-y-2">
+            <a href="#features" className="block py-2" onClick={() => setMenuOpen(false)}>Features</a>
+            <button
+              className="w-full bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
+              onClick={() => { setMenuOpen(false); onGetStarted(); }}
+            >
+              Launch App
+            </button>
+          </div>
+        )}
       </header>
       <main className="flex-1 flex flex-col items-center justify-center text-center px-4">
         <h2 className="text-4xl sm:text-6xl font-extrabold mb-6">
@@ -25,16 +48,19 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           Stop wasting hours editing. CineSynth turns your script into shareable videos in minutes&mdash;perfect for busy YouTubers and marketing strategists.
         </p>
 
-        <div className="grid gap-6 sm:grid-cols-3 max-w-4xl mb-8 text-left">
-          <div>
+        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mb-8 text-left">
+          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
+            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">Trend Analysis</h3>
             <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
           </div>
-          <div>
+          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
+            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">No Editing Required</h3>
             <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
           </div>
-          <div>
+          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
+            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">Controversy Ready</h3>
             <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
           </div>

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -10,7 +10,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ progress, message }) => {
   return (
     <div className="w-full my-4">
       {message && <p className="text-sm text-gray-400 mb-1 text-center">{message}</p>}
-      <div className="w-full bg-gray-700 rounded-full h-2.5">
+      <div className="w-full bg-gray-800 rounded-full h-2.5">
         <div
           className="bg-fuchsia-500 h-2.5 rounded-full transition-all duration-300 ease-out"
           style={{ width: `${progress}%` }}

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -56,12 +56,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
 
 
   return (
-    <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
+    <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
       <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>4. Edit Scenes</h3>
       {scenes.length === 0 && <p className="text-gray-400">No scenes generated yet. Use Step 1 & 2.</p>}
       <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
         {scenes.map((scene, index) => (
-          <div key={scene.id} className="bg-gray-700 p-4 rounded-lg shadow-md">
+          <div key={scene.id} className="bg-gray-900 p-4 rounded-lg shadow-md">
             <h4 className="font-semibold text-fuchsia-300 mb-2" style={{ fontFamily: 'Fira Code' }}>Scene {index + 1}</h4>
             {editableSceneId === scene.id ? (
               <div className="space-y-3">
@@ -72,7 +72,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editText}
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
-                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -84,7 +84,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editDuration}
                     onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
                     min="1"
-                    className="w-full p-2 bg-gray-800 border border-gray-600 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>

--- a/components/TextInputArea.tsx
+++ b/components/TextInputArea.tsx
@@ -16,7 +16,7 @@ const TextInputArea: React.FC<TextInputAreaProps> = ({ value, onChange, placehol
       placeholder={placeholder || "Enter your narration here..."}
       disabled={disabled}
       rows={8}
-      className="w-full p-4 bg-gray-800 border border-gray-700 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
+      className="w-full p-4 bg-gray-900 border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
     />
   );
 };

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -270,7 +270,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (scenes.length === 0 && !isGenerating) {
     return (
-      <div className={`w-full bg-gray-800 rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         Enter narration and click "Generate Video" to see preview.
       </div>
     );
@@ -278,7 +278,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (isGenerating && scenes.length === 0) {
      return (
-      <div className={`w-full bg-gray-800 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-500 mb-4"></div>
         <p>Generating scenes & visuals...</p>
       </div>
@@ -289,7 +289,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const playedDuration = scenes.slice(0, currentSceneIndex).reduce((sum, s) => sum + s.duration, 0) + (elapsedTime / 1000);
 
   return (
-    <div className="bg-gray-800 p-1 sm:p-2 rounded-lg shadow-xl">
+    <div className="bg-gray-900 p-1 sm:p-2 rounded-lg shadow-xl">
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (
@@ -307,7 +307,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
         )}
       </div>
       {scenes.length > 0 && (
-        <div className="mt-2 h-2 bg-gray-700 rounded-full overflow-hidden">
+        <div className="mt-2 h-2 bg-gray-800 rounded-full overflow-hidden">
           <div className="h-full bg-fuchsia-500" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
         </div>
       )}
@@ -316,7 +316,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           <button
             onClick={handlePlayPause}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-fuchsia-400 hover:text-fuchsia-300"
+            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-fuchsia-400 hover:text-fuchsia-300"
             aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isPlaying ? <PauseIcon className="w-5 h-5 sm:w-6 sm:h-6" /> : <PlayIcon className="w-5 h-5 sm:w-6 sm:h-6" />}
@@ -324,7 +324,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
            <button
             onClick={handleRestart}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-700 hover:bg-gray-600 disabled:opacity-50 transition-colors text-sm text-fuchsia-400 hover:text-fuchsia-300"
+            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-sm text-fuchsia-400 hover:text-fuchsia-300"
             aria-label="Restart"
           >
             Restart


### PR DESCRIPTION
## Summary
- implement responsive navbar with mobile menu
- add heroicons for navigation and feature list
- upgrade feature section with icons
- darken app card backgrounds for consistent branding

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f13ebdbfc832eb5817e8d6a0ec3a0