### PR TITLE
Improve landing page layout and features

### DIFF
--- a/components/IconComponents.tsx
+++ b/components/IconComponents.tsx
@@ -67,3 +67,24 @@ export const FireIcon: React.FC<{ className?: string }> = ({ className }) => (
     <path d="M9.879 16.121a3 3 0 0 0 4.242 0c.586-.586.879-1.354.879-2.121s-.293-1.535-.879-2.121C13.539 11.296 12.778 11 12 11v3l-2 .001c0 .768.293 1.536.879 2.12Z" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
+
+export const EyeIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z" strokeLinecap="round" strokeLinejoin="round" />
+    <circle cx="12" cy="12" r="3" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const ShieldIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M12 2l7 4v5c0 5.523-3.806 10.74-7 11-3.194-.26-7-5.477-7-11V6l7-4Z" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M12 11v5" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M9 14h6" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const BoltIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M13 2L3 14h7v8l10-12h-7l0-8Z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon } from './IconComponents.tsx';
+import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, EyeIcon, ShieldIcon, BoltIcon } from './IconComponents.tsx';
 
 interface LandingPageProps {
   onGetStarted: () => void;
@@ -9,8 +9,8 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
     <div className="min-h-screen flex flex-col bg-black text-white">
-      <header className="bg-black/70 backdrop-blur sticky top-0 z-10">
-        <nav className="max-w-6xl mx-auto flex justify-between items-center p-4">
+      <header className="bg-gradient-to-b from-black via-gray-900/80 to-black/60 backdrop-blur-lg sticky top-0 z-10 shadow-md">
+        <nav className="max-w-6xl mx-auto flex justify-between items-center px-4 py-3 md:py-4 border-b border-gray-800">
           <h1 className="text-3xl font-bold text-fuchsia-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
           <div className="hidden sm:flex items-center gap-6">
             <a href="#features" className="hover:text-fuchsia-400 transition-colors">Features</a>
@@ -22,14 +22,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
             </button>
           </div>
           <button
-            className="sm:hidden p-2 rounded-md hover:bg-gray-900"
+            className="sm:hidden p-2 rounded-md hover:bg-gray-900/80"
             onClick={() => setMenuOpen(!menuOpen)}
           >
             {menuOpen ? <CloseIcon className="w-6 h-6" /> : <MenuIcon className="w-6 h-6" />}
           </button>
         </nav>
         {menuOpen && (
-          <div className="sm:hidden px-4 pb-4 space-y-2">
+          <div className="sm:hidden bg-black/80 px-4 pb-4 pt-2 space-y-2 border-b border-gray-800">
             <a href="#features" className="block py-2" onClick={() => setMenuOpen(false)}>Features</a>
             <button
               className="w-full bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
@@ -48,24 +48,6 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           Stop wasting hours editing. CineSynth turns your script into shareable videos in minutes&mdash;perfect for busy YouTubers and marketing strategists.
         </p>
 
-        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mb-8 text-left">
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">Trend Analysis</h3>
-            <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
-          </div>
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">No Editing Required</h3>
-            <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
-          </div>
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">Controversy Ready</h3>
-            <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
-          </div>
-        </div>
-
         <button
           onClick={onGetStarted}
           className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white text-lg px-8 py-4 rounded-full shadow-xl flex items-center gap-2"
@@ -73,6 +55,42 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           <SparklesIcon className="w-6 h-6" />
           Get Started
         </button>
+
+        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-8 text-left">
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Trend Analysis</h3>
+            <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
+          </div>
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">No Editing Required</h3>
+            <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
+          </div>
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Controversy Ready</h3>
+            <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-8 text-left">
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <EyeIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Shadow Metrics</h3>
+            <p className="text-gray-400 text-sm mt-1">Mine hidden viewer data to fuel irresistible narratives.</p>
+          </div>
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <ShieldIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Cancel Guard</h3>
+            <p className="text-gray-400 text-sm mt-1">Predict backlash ahead of time so your brand stays untouchable.</p>
+          </div>
+          <div className="p-6 bg-gray-950 rounded-xl shadow-lg">
+            <BoltIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Shockwave Boost</h3>
+            <p className="text-gray-400 text-sm mt-1">Inject viral energy that provokes instant debate.</p>
+          </div>
+        </div>
       </main>
       <footer className="p-4 text-center text-gray-500 text-sm">
         <p>&copy; {new Date().getFullYear()} CineSynth. AI that disrupts filmmaking.</p>


### PR DESCRIPTION
## Summary
- style header with gradient and shadow
- move feature cards below the CTA
- add dark backgrounds and three new unique sections
- include new icons for the features

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f1812bc0c832e8b4f9303e1830b28