### PR TITLE
Improve landing layout and add features

### DIFF
--- a/components/IconComponents.tsx
+++ b/components/IconComponents.tsx
@@ -67,3 +67,21 @@ export const FireIcon: React.FC<{ className?: string }> = ({ className }) => (
     <path d="M9.879 16.121a3 3 0 0 0 4.242 0c.586-.586.879-1.354.879-2.121s-.293-1.535-.879-2.121C13.539 11.296 12.778 11 12 11v3l-2 .001c0 .768.293 1.536.879 2.12Z" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 );
+
+export const PulseIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M2 12h4l3-8 4 16 3-8h4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const BoltIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M13 2L3 14h8l-1 8L21 10h-8l1-8z" />
+  </svg>
+);
+
+export const HookIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M12 2v12a4 4 0 1 0 4-4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon } from './IconComponents.tsx';
+import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, PulseIcon, BoltIcon, HookIcon } from './IconComponents.tsx';
 
 interface LandingPageProps {
   onGetStarted: () => void;
@@ -29,10 +29,13 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </button>
         </nav>
         {menuOpen && (
-          <div className="sm:hidden px-4 pb-4 space-y-2">
-            <a href="#features" className="block py-2" onClick={() => setMenuOpen(false)}>Features</a>
+          <div className="sm:hidden fixed inset-0 bg-black/90 z-20 flex flex-col items-center justify-center space-y-6">
+            <button className="absolute top-4 right-4 p-2" onClick={() => setMenuOpen(false)}>
+              <CloseIcon className="w-6 h-6" />
+            </button>
+            <a href="#features" className="text-xl" onClick={() => setMenuOpen(false)}>Features</a>
             <button
-              className="w-full bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
+              className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-6 py-3 rounded-md shadow-lg"
               onClick={() => { setMenuOpen(false); onGetStarted(); }}
             >
               Launch App
@@ -48,24 +51,6 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           Stop wasting hours editing. CineSynth turns your script into shareable videos in minutes&mdash;perfect for busy YouTubers and marketing strategists.
         </p>
 
-        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mb-8 text-left">
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">Trend Analysis</h3>
-            <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
-          </div>
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">No Editing Required</h3>
-            <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
-          </div>
-          <div className="p-6 bg-gray-900 rounded-xl shadow-lg">
-            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
-            <h3 className="font-semibold text-white">Controversy Ready</h3>
-            <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
-          </div>
-        </div>
-
         <button
           onClick={onGetStarted}
           className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white text-lg px-8 py-4 rounded-full shadow-xl flex items-center gap-2"
@@ -73,6 +58,42 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           <SparklesIcon className="w-6 h-6" />
           Get Started
         </button>
+
+        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-8 text-left">
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Trend Analysis</h3>
+            <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
+          </div>
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">No Editing Required</h3>
+            <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
+          </div>
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Controversy Ready</h3>
+            <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
+          </div>
+        </div>
+
+        <div id="extras" className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-12 text-left">
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <PulseIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Audience Pulse</h3>
+            <p className="text-gray-400 text-sm mt-1">Gauge comment sentiment live and adapt your message on the fly.</p>
+          </div>
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <BoltIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Shockwave Scripts</h3>
+            <p className="text-gray-400 text-sm mt-1">AI-crafted hot takes engineered to ignite debate.</p>
+          </div>
+          <div className="p-6 bg-black rounded-xl shadow-lg">
+            <HookIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+            <h3 className="font-semibold text-white">Behavioral Hooks</h3>
+            <p className="text-gray-400 text-sm mt-1">Openers and closers optimized for maximum watch time.</p>
+          </div>
+        </div>
       </main>
       <footer className="p-4 text-center text-gray-500 text-sm">
         <p>&copy; {new Date().getFullYear()} CineSynth. AI that disrupts filmmaking.</p>


### PR DESCRIPTION
## Summary
- tweak mobile navigation with full-screen overlay
- move feature grid below the Get Started button
- add three new attention-grabbing features
- darken feature cards
- provide icons for new features

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f1afdb594832e935c8b5bda943167