### PR TITLE
Adjust colors and extras

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -350,7 +350,7 @@ const App: React.FC = () => {
 
       <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-black p-4 sm:p-6 rounded-xl shadow-2xl">
             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>1. Enter Your Narration</h2>
             <TextInputArea
               value={narrationText}
@@ -359,7 +359,7 @@ const App: React.FC = () => {
               disabled={isGeneratingScenes || apiKeyMissing || isRenderingVideo}
             />
           </div>
-          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-black p-4 sm:p-6 rounded-xl shadow-2xl">
              <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>2. Configure & Generate</h2>
             <Controls
               aspectRatio={aspectRatio}
@@ -385,7 +385,7 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        <div className="lg:col-span-2 bg-gray-900 p-1 sm:p-2 rounded-xl shadow-2xl">
+        <div className="lg:col-span-2 bg-black p-1 sm:p-2 rounded-xl shadow-2xl">
            <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-fuchsia-400 px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -39,7 +39,7 @@ const Controls: React.FC<ControlsProps> = ({
   const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
 
   return (
-    <div className="p-4 bg-gray-900 rounded-lg shadow-lg space-y-6">
+    <div className="p-4 bg-black rounded-lg shadow-lg space-y-6">
       <div>
         <label className="block text-sm font-medium text-gray-300 mb-2">Aspect Ratio</label>
         <div className="flex space-x-2">

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -92,6 +92,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
               <span className="text-fuchsia-500 font-semibold">Polarizing Hook Generator:</span>
               <span className="ml-1 text-gray-400">Crafts openings designed to split opinions and fuel comment wars.</span>
             </li>
+            <li>
+              <span className="text-fuchsia-500 font-semibold">Shockwave Scheduler:</span>
+              <span className="ml-1 text-gray-400">Times releases for peak impact across global viewer zones.</span>
+            </li>
+            <li>
+              <span className="text-fuchsia-500 font-semibold">Deep Trend Miner:</span>
+              <span className="ml-1 text-gray-400">Unearths hidden subcultures so you can target emerging niches first.</span>
+            </li>
           </ul>
         </section>
       </main>

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -56,12 +56,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
 
 
   return (
-    <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+    <div className="bg-black p-4 sm:p-6 rounded-xl shadow-2xl">
       <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>4. Edit Scenes</h3>
       {scenes.length === 0 && <p className="text-gray-400">No scenes generated yet. Use Step 1 & 2.</p>}
       <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
         {scenes.map((scene, index) => (
-          <div key={scene.id} className="bg-gray-900 p-4 rounded-lg shadow-md">
+          <div key={scene.id} className="bg-black p-4 rounded-lg shadow-md">
             <h4 className="font-semibold text-fuchsia-300 mb-2" style={{ fontFamily: 'Fira Code' }}>Scene {index + 1}</h4>
             {editableSceneId === scene.id ? (
               <div className="space-y-3">
@@ -72,7 +72,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editText}
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-black border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -84,7 +84,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editDuration}
                     onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
                     min="1"
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-black border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>

--- a/components/TextInputArea.tsx
+++ b/components/TextInputArea.tsx
@@ -16,7 +16,7 @@ const TextInputArea: React.FC<TextInputAreaProps> = ({ value, onChange, placehol
       placeholder={placeholder || "Enter your narration here..."}
       disabled={disabled}
       rows={8}
-      className="w-full p-4 bg-gray-900 border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
+      className="w-full p-4 bg-black border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
     />
   );
 };

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -270,7 +270,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (scenes.length === 0 && !isGenerating) {
     return (
-      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-black rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         Enter narration and click "Generate Video" to see preview.
       </div>
     );
@@ -278,7 +278,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (isGenerating && scenes.length === 0) {
      return (
-      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-black rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-500 mb-4"></div>
         <p>Generating scenes & visuals...</p>
       </div>
@@ -289,7 +289,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const playedDuration = scenes.slice(0, currentSceneIndex).reduce((sum, s) => sum + s.duration, 0) + (elapsedTime / 1000);
 
   return (
-    <div className="bg-gray-900 p-1 sm:p-2 rounded-lg shadow-xl">
+    <div className="bg-black p-1 sm:p-2 rounded-lg shadow-xl">
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (


### PR DESCRIPTION
## Summary
- change main app step cards to match landing page colors
- keep input, preview, and scene editor consistent with black card styling
- extend the "Disruptive Extras" list with more features

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f1dbfee64832e80dcd25a5b085c37