### PR TITLE
Improve card styling and extras UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -350,7 +350,7 @@ const App: React.FC = () => {
 
       <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
         <div className="lg:col-span-1 space-y-6">
-          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>1. Enter Your Narration</h2>
             <TextInputArea
               value={narrationText}
@@ -359,7 +359,7 @@ const App: React.FC = () => {
               disabled={isGeneratingScenes || apiKeyMissing || isRenderingVideo}
             />
           </div>
-          <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+          <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
              <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>2. Configure & Generate</h2>
             <Controls
               aspectRatio={aspectRatio}
@@ -385,7 +385,7 @@ const App: React.FC = () => {
           </div>
         </div>
 
-        <div className="lg:col-span-2 bg-gray-900 p-1 sm:p-2 rounded-xl shadow-2xl">
+        <div className="lg:col-span-2 bg-gray-800 p-1 sm:p-2 rounded-xl shadow-2xl">
            <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-fuchsia-400 px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -39,7 +39,7 @@ const Controls: React.FC<ControlsProps> = ({
   const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
 
   return (
-    <div className="p-4 bg-gray-900 rounded-lg shadow-lg space-y-6">
+    <div className="p-4 bg-gray-800 rounded-lg shadow-lg space-y-6">
       <div>
         <label className="block text-sm font-medium text-gray-300 mb-2">Aspect Ratio</label>
         <div className="flex space-x-2">

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -60,17 +60,17 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
         </button>
 
         <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-12 mb-8 text-left">
-          <div className="p-6 bg-black rounded-xl shadow-lg">
+          <div className="p-6 bg-gray-800 rounded-xl shadow-lg">
             <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">Trend Analysis</h3>
             <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
           </div>
-          <div className="p-6 bg-black rounded-xl shadow-lg">
+          <div className="p-6 bg-gray-800 rounded-xl shadow-lg">
             <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">No Editing Required</h3>
             <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
           </div>
-          <div className="p-6 bg-black rounded-xl shadow-lg">
+          <div className="p-6 bg-gray-800 rounded-xl shadow-lg">
             <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
             <h3 className="font-semibold text-white">Controversy Ready</h3>
             <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
@@ -79,18 +79,27 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
 
         <section className="w-full py-12 border-t border-gray-800 mt-8">
           <h3 className="text-3xl font-bold mb-8 text-center">Disruptive Extras</h3>
-          <ul className="space-y-6 max-w-3xl mx-auto text-left text-lg">
-            <li>
-              <span className="text-fuchsia-500 font-semibold">Echo Chamber Amplifier:</span>
-              <span className="ml-1 text-gray-400">Analyzes viewer tribes and doubles down on the narratives they crave.</span>
+          <ul className="space-y-4 max-w-3xl mx-auto text-left text-lg">
+            <li className="flex items-start">
+              <SparklesIcon className="w-6 h-6 text-fuchsia-500 flex-shrink-0 mt-1 mr-2" />
+              <p>
+                <span className="text-fuchsia-400 font-semibold">Echo Chamber Amplifier:</span>
+                <span className="ml-1 text-gray-400">Analyzes viewer tribes and doubles down on the narratives they crave.</span>
+              </p>
             </li>
-            <li>
-              <span className="text-fuchsia-500 font-semibold">Trend Jacker:</span>
-              <span className="ml-1 text-gray-400">Injects real-time social spikes into your storylines for viral momentum.</span>
+            <li className="flex items-start">
+              <TrendingUpIcon className="w-6 h-6 text-fuchsia-500 flex-shrink-0 mt-1 mr-2" />
+              <p>
+                <span className="text-fuchsia-400 font-semibold">Trend Jacker:</span>
+                <span className="ml-1 text-gray-400">Injects real-time social spikes into your storylines for viral momentum.</span>
+              </p>
             </li>
-            <li>
-              <span className="text-fuchsia-500 font-semibold">Polarizing Hook Generator:</span>
-              <span className="ml-1 text-gray-400">Crafts openings designed to split opinions and fuel comment wars.</span>
+            <li className="flex items-start">
+              <FireIcon className="w-6 h-6 text-fuchsia-500 flex-shrink-0 mt-1 mr-2" />
+              <p>
+                <span className="text-fuchsia-400 font-semibold">Polarizing Hook Generator:</span>
+                <span className="ml-1 text-gray-400">Crafts openings designed to split opinions and fuel comment wars.</span>
+              </p>
             </li>
           </ul>
         </section>

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -56,12 +56,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
 
 
   return (
-    <div className="bg-gray-900 p-4 sm:p-6 rounded-xl shadow-2xl">
+    <div className="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-2xl">
       <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>4. Edit Scenes</h3>
       {scenes.length === 0 && <p className="text-gray-400">No scenes generated yet. Use Step 1 & 2.</p>}
       <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
         {scenes.map((scene, index) => (
-          <div key={scene.id} className="bg-gray-900 p-4 rounded-lg shadow-md">
+          <div key={scene.id} className="bg-gray-800 p-4 rounded-lg shadow-md">
             <h4 className="font-semibold text-fuchsia-300 mb-2" style={{ fontFamily: 'Fira Code' }}>Scene {index + 1}</h4>
             {editableSceneId === scene.id ? (
               <div className="space-y-3">
@@ -72,7 +72,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editText}
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-800 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -84,7 +84,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editDuration}
                     onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
                     min="1"
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-800 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
                     disabled={isGenerating}
                   />
                 </div>

--- a/components/TextInputArea.tsx
+++ b/components/TextInputArea.tsx
@@ -16,7 +16,7 @@ const TextInputArea: React.FC<TextInputAreaProps> = ({ value, onChange, placehol
       placeholder={placeholder || "Enter your narration here..."}
       disabled={disabled}
       rows={8}
-      className="w-full p-4 bg-gray-900 border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
+      className="w-full p-4 bg-gray-800 border border-gray-700 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
     />
   );
 };

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -270,7 +270,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (scenes.length === 0 && !isGenerating) {
     return (
-      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-gray-800 rounded-lg shadow-lg flex items-center justify-center text-gray-500 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         Enter narration and click "Generate Video" to see preview.
       </div>
     );
@@ -278,7 +278,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   if (isGenerating && scenes.length === 0) {
      return (
-      <div className={`w-full bg-gray-900 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
+      <div className={`w-full bg-gray-800 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-500 mb-4"></div>
         <p>Generating scenes & visuals...</p>
       </div>
@@ -289,7 +289,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const playedDuration = scenes.slice(0, currentSceneIndex).reduce((sum, s) => sum + s.duration, 0) + (elapsedTime / 1000);
 
   return (
-    <div className="bg-gray-900 p-1 sm:p-2 rounded-lg shadow-xl">
+    <div className="bg-gray-800 p-1 sm:p-2 rounded-lg shadow-xl">
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (


### PR DESCRIPTION
## Summary
- lighten card backgrounds across the app
- match feature card color on landing page
- add icons and improved layout in the Disruptive Extras section

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f1eec675c832eb199ed0e390a1858