### PR TITLE
Improve landing layout and colors

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -328,9 +328,9 @@ const App: React.FC = () => {
     <div className="min-h-screen bg-black text-white flex flex-col items-center p-4 sm:p-6 lg:p-8">
       <header className="mb-6 sm:mb-8 text-center">
         <div className="flex items-center justify-center space-x-3">
-           <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-fuchsia-400" />
+           <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-emerald-400" />
            <h1
-             className="glitch text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight bg-gradient-to-r from-fuchsia-400 via-pink-500 to-red-500 text-transparent bg-clip-text"
+             className="glitch text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight bg-gradient-to-r from-emerald-400 via-teal-500 to-cyan-500 text-transparent bg-clip-text"
              style={{ fontFamily: 'Fira Code' }}
              data-text={APP_TITLE}
            >
@@ -351,7 +351,7 @@ const App: React.FC = () => {
       <div className="w-full max-w-5xl grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
         <div className="lg:col-span-1 space-y-6">
           <div className="bg-gray-900 border border-gray-700 p-4 sm:p-6 rounded-xl shadow-2xl">
-            <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>1. Enter Your Narration</h2>
+            <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-emerald-400" style={{ fontFamily: 'Fira Code' }}>1. Enter Your Narration</h2>
             <TextInputArea
               value={narrationText}
               onChange={setNarrationText}
@@ -360,7 +360,7 @@ const App: React.FC = () => {
             />
           </div>
           <div className="bg-gray-900 border border-gray-700 p-4 sm:p-6 rounded-xl shadow-2xl">
-             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>2. Configure & Generate</h2>
+             <h2 className="text-xl sm:text-2xl font-semibold mb-4 text-emerald-400" style={{ fontFamily: 'Fira Code' }}>2. Configure & Generate</h2>
             <Controls
               aspectRatio={aspectRatio}
               onAspectRatioChange={(ratio) => {
@@ -386,7 +386,7 @@ const App: React.FC = () => {
         </div>
 
         <div className="lg:col-span-2 bg-gray-900 border border-gray-700 p-1 sm:p-2 rounded-xl shadow-2xl">
-           <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-fuchsia-400 px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
+           <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-emerald-400 px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}
             aspectRatio={aspectRatio}

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -49,8 +49,8 @@ const Controls: React.FC<ControlsProps> = ({
               type="button"
               onClick={() => onAspectRatioChange(ratio)}
               disabled={isGenerating}
-              className={`flex-1 p-3 rounded-md text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-fuchsia-500
-                ${aspectRatio === ratio ? 'bg-fuchsia-600 text-white shadow-md' : 'bg-gray-800 text-gray-300 hover:bg-gray-700'}
+              className={`flex-1 p-3 rounded-md text-sm font-medium transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-emerald-500
+                ${aspectRatio === ratio ? 'bg-emerald-600 text-white shadow-md' : 'bg-gray-800 text-gray-300 hover:bg-gray-700'}
                 ${isGenerating ? 'opacity-50 cursor-not-allowed' : ''}`}
               aria-pressed={aspectRatio === ratio}
             >
@@ -71,7 +71,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={useAiImages}
             onChange={(e) => onUseAiImagesChange(e.target.checked)}
             disabled={isGenerating || apiKeyMissing}
-            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-emerald-600 border-gray-600 rounded focus:ring-emerald-500 bg-gray-800 mr-2 disabled:opacity-50"
           />
           Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
         </label>
@@ -85,7 +85,7 @@ const Controls: React.FC<ControlsProps> = ({
             checked={includeSubtitlesOnDownload}
             onChange={(e) => onIncludeSubtitlesChange(e.target.checked)}
             disabled={isGenerating}
-            className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
+            className="h-4 w-4 text-emerald-600 border-gray-600 rounded focus:ring-emerald-500 bg-gray-800 mr-2 disabled:opacity-50"
           />
           Include subtitles in download
         </label>
@@ -99,7 +99,7 @@ const Controls: React.FC<ControlsProps> = ({
               checked={isTTSEnabled}
               onChange={(e) => onTTSEnabledChange(e.target.checked)}
               disabled={isGenerating}
-              className="h-4 w-4 text-fuchsia-600 border-gray-600 rounded focus:ring-fuchsia-500 bg-gray-800 mr-2 disabled:opacity-50"
+              className="h-4 w-4 text-emerald-600 border-gray-600 rounded focus:ring-emerald-500 bg-gray-800 mr-2 disabled:opacity-50"
             />
             Enable TTS Narration (Preview)
           </label>
@@ -110,7 +110,7 @@ const Controls: React.FC<ControlsProps> = ({
         onClick={onGenerate}
         disabled={!canGenerate}
         className={`w-full flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white
-                  ${!canGenerate ? 'bg-gray-600 cursor-not-allowed' : 'bg-fuchsia-600 hover:bg-fuchsia-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-fuchsia-500'}
+                  ${!canGenerate ? 'bg-gray-600 cursor-not-allowed' : 'bg-emerald-600 hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-emerald-500'}
                   transition-colors duration-150`}
         aria-live="polite"
         title={apiKeyMissing ? "API Key is missing. Cannot generate." : (narrationText.trim() === '' ? "Please enter narration text." : (hasScenes ? "Re-analyze narration & generate new scenes" : "Generate Video"))}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -11,11 +11,11 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
     <div className="min-h-screen flex flex-col bg-black text-white">
       <header className="bg-black/70 backdrop-blur sticky top-0 z-10">
         <nav className="max-w-6xl mx-auto flex justify-between items-center p-4">
-          <h1 className="text-3xl font-bold text-fuchsia-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
+          <h1 className="text-3xl font-bold text-emerald-500" style={{fontFamily:'Fira Code'}}>CineSynth</h1>
           <div className="hidden sm:flex items-center gap-6">
-            <a href="#features" className="hover:text-fuchsia-400 transition-colors">Features</a>
+            <a href="#features" className="hover:text-emerald-300 transition-colors">Features</a>
             <button
-              className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-4 py-2 rounded-md shadow-lg"
+              className="bg-emerald-600 hover:bg-emerald-500 text-white px-4 py-2 rounded-md shadow-lg"
               onClick={onGetStarted}
             >
               Launch App
@@ -29,10 +29,10 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </button>
         </nav>
         {menuOpen && (
-          <div className="sm:hidden fixed inset-0 bg-black/90 backdrop-blur flex flex-col items-center justify-center space-y-6 z-20">
+          <div className="sm:hidden fixed inset-0 bg-black/90 backdrop-blur flex flex-col items-center justify-center space-y-6 z-20 relative">
             <a href="#features" className="text-2xl" onClick={() => setMenuOpen(false)}>Features</a>
             <button
-              className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white px-6 py-3 rounded-md text-lg shadow-lg"
+              className="bg-emerald-600 hover:bg-emerald-500 text-white px-6 py-3 rounded-md text-lg shadow-lg"
               onClick={() => { setMenuOpen(false); onGetStarted(); }}
             >
               Launch App
@@ -43,7 +43,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </div>
         )}
       </header>
-      <main className="flex-1 flex flex-col items-center justify-center text-center px-4">
+      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 pt-20">
         <h2 className="text-4xl sm:text-6xl font-extrabold mb-6">
           Your Marketing Video Sidekick
         </h2>
@@ -53,25 +53,25 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
 
         <button
           onClick={onGetStarted}
-          className="bg-fuchsia-600 hover:bg-fuchsia-500 text-white text-lg px-8 py-4 rounded-full shadow-xl flex items-center gap-2"
+          className="bg-emerald-600 hover:bg-emerald-500 text-white text-lg px-8 py-4 rounded-full shadow-xl flex items-center gap-2"
         >
           <SparklesIcon className="w-6 h-6" />
           Get Started
         </button>
 
-        <div id="features" className="grid gap-6 sm:grid-cols-3 max-w-4xl mt-12 mb-8 text-left">
-          <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-            <TrendingUpIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+        <div id="features" className="flex overflow-x-auto snap-x snap-mandatory gap-6 sm:grid sm:grid-cols-3 max-w-4xl mt-12 mb-8 text-left">
+          <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+            <TrendingUpIcon className="w-8 h-8 text-emerald-500 mb-3" />
             <h3 className="font-semibold text-white">Trend Analysis</h3>
-            <p className="text-gray-400 text-sm mt-1">AI taps into viewer behavior so your content always hits the mark.</p>
+            <p className="text-gray-400 text-sm mt-1">AI exploits viewer habits so ruthlessly, your content is impossible to ignore.</p>
           </div>
-          <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-            <ScissorsIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+          <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+            <ScissorsIcon className="w-8 h-8 text-emerald-500 mb-3" />
             <h3 className="font-semibold text-white">No Editing Required</h3>
             <p className="text-gray-400 text-sm mt-1">Just talk. We handle visuals, timing and audio sync automatically.</p>
           </div>
-          <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-            <FireIcon className="w-8 h-8 text-fuchsia-500 mb-3" />
+          <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+            <FireIcon className="w-8 h-8 text-emerald-500 mb-3" />
             <h3 className="font-semibold text-white">Controversy Ready</h3>
             <p className="text-gray-400 text-sm mt-1">Create bold videos that spark engagement without the headaches.</p>
           </div>
@@ -79,17 +79,17 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
 
         <section className="w-full py-12 border-t border-gray-800 mt-8">
           <h3 className="text-3xl font-bold mb-8 text-center">Disruptive Extras</h3>
-          <div className="grid gap-6 sm:grid-cols-3 max-w-5xl mx-auto text-left">
-            <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-              <span className="text-fuchsia-500 font-semibold block mb-2">Echo Chamber Amplifier</span>
+          <div className="flex overflow-x-auto snap-x snap-mandatory gap-6 sm:grid sm:grid-cols-3 max-w-5xl mx-auto text-left">
+            <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+              <span className="text-emerald-500 font-semibold block mb-2">Echo Chamber Amplifier</span>
               <p className="text-gray-400 text-sm">Our algorithms map each tribe’s beliefs, letting you magnify the stories they already cling to.</p>
             </div>
-            <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-              <span className="text-fuchsia-500 font-semibold block mb-2">Trend Jacker</span>
+            <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+              <span className="text-emerald-500 font-semibold block mb-2">Trend Jacker</span>
               <p className="text-gray-400 text-sm">We detect the hottest memes and weave them into your narrative within seconds, fueling unstoppable virality.</p>
             </div>
-            <div className="p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg">
-              <span className="text-fuchsia-500 font-semibold block mb-2">Polarizing Hook Generator</span>
+            <div className="flex-shrink-0 w-72 sm:w-auto p-6 bg-gray-900 border border-gray-700 rounded-xl shadow-lg snap-center">
+              <span className="text-emerald-500 font-semibold block mb-2">Polarizing Hook Generator</span>
               <p className="text-gray-400 text-sm">Kick off with lines engineered to divide the room and keep the comment section raging.</p>
             </div>
           </div>

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -12,7 +12,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ progress, message }) => {
       {message && <p className="text-sm text-gray-400 mb-1 text-center">{message}</p>}
       <div className="w-full bg-gray-800 rounded-full h-2.5">
         <div
-          className="bg-fuchsia-500 h-2.5 rounded-full transition-all duration-300 ease-out"
+          className="bg-emerald-500 h-2.5 rounded-full transition-all duration-300 ease-out"
           style={{ width: `${progress}%` }}
         ></div>
       </div>

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -57,12 +57,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
 
   return (
     <div className="bg-gray-900 border border-gray-700 p-4 sm:p-6 rounded-xl shadow-2xl">
-      <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-fuchsia-400" style={{ fontFamily: 'Fira Code' }}>4. Edit Scenes</h3>
+      <h3 className="text-xl sm:text-2xl font-semibold mb-4 text-emerald-400" style={{ fontFamily: 'Fira Code' }}>4. Edit Scenes</h3>
       {scenes.length === 0 && <p className="text-gray-400">No scenes generated yet. Use Step 1 & 2.</p>}
       <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-2">
         {scenes.map((scene, index) => (
           <div key={scene.id} className="bg-gray-900 border border-gray-700 p-4 rounded-lg shadow-md">
-            <h4 className="font-semibold text-fuchsia-300 mb-2" style={{ fontFamily: 'Fira Code' }}>Scene {index + 1}</h4>
+            <h4 className="font-semibold text-emerald-300 mb-2" style={{ fontFamily: 'Fira Code' }}>Scene {index + 1}</h4>
             {editableSceneId === scene.id ? (
               <div className="space-y-3">
                 <div>
@@ -72,7 +72,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editText}
                     onChange={(e) => setEditText(e.target.value)}
                     rows={3}
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-emerald-500 focus:border-emerald-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -84,7 +84,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     value={editDuration}
                     onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
                     min="1"
-                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                    className="w-full p-2 bg-gray-900 border border-gray-700 rounded-md text-gray-200 focus:ring-emerald-500 focus:border-emerald-500"
                     disabled={isGenerating}
                   />
                 </div>
@@ -92,7 +92,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                   <button
                     onClick={() => handleSave(scene.id)}
                     disabled={isGenerating}
-                    className="px-3 py-1.5 text-sm bg-fuchsia-600 hover:bg-fuchsia-500 rounded-md text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-sm bg-emerald-600 hover:bg-emerald-500 rounded-md text-white disabled:opacity-50"
                   >
                     Save Changes
                   </button>
@@ -125,14 +125,14 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                   <button
                     onClick={() => handleEdit(scene)}
                     disabled={isGenerating || isUpdatingImage === scene.id}
-                    className="px-3 py-1.5 text-xs bg-fuchsia-600 hover:bg-fuchsia-500 rounded-md text-white disabled:opacity-50"
+                    className="px-3 py-1.5 text-xs bg-emerald-600 hover:bg-emerald-500 rounded-md text-white disabled:opacity-50"
                   >
                     Edit Scene
                   </button>
                   <button
                     onClick={() => handleImageUpdate(scene.id)}
                     disabled={isGenerating || apiKeyMissing || isUpdatingImage === scene.id}
-                    className="px-3 py-1.5 text-xs bg-fuchsia-600 hover:bg-fuchsia-500 rounded-md text-white disabled:opacity-50 flex items-center"
+                    className="px-3 py-1.5 text-xs bg-emerald-600 hover:bg-emerald-500 rounded-md text-white disabled:opacity-50 flex items-center"
                     title={apiKeyMissing && useAiImagesGlobal ? "API Key missing, cannot generate AI image" : (useAiImagesGlobal ? "Refresh AI Image" : "Refresh Placeholder")}
                   >
                      {isUpdatingImage === scene.id ? (
@@ -158,7 +158,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
       <button
         onClick={onAddScene}
         disabled={isGenerating}
-        className="mt-6 w-full px-4 py-2 bg-fuchsia-600 hover:bg-fuchsia-500 rounded-md text-white font-medium disabled:opacity-50"
+        className="mt-6 w-full px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded-md text-white font-medium disabled:opacity-50"
       >
         Add New Scene
       </button>

--- a/components/TextInputArea.tsx
+++ b/components/TextInputArea.tsx
@@ -16,7 +16,7 @@ const TextInputArea: React.FC<TextInputAreaProps> = ({ value, onChange, placehol
       placeholder={placeholder || "Enter your narration here..."}
       disabled={disabled}
       rows={8}
-      className="w-full p-4 bg-gray-900 border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
+      className="w-full p-4 bg-gray-900 border border-gray-800 rounded-lg shadow-md focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 text-gray-200 placeholder-gray-500 resize-y transition-colors duration-150"
     />
   );
 };

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -279,7 +279,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   if (isGenerating && scenes.length === 0) {
      return (
       <div className={`w-full bg-gray-900 border border-gray-700 rounded-lg shadow-lg flex flex-col items-center justify-center text-gray-400 ${aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]'}`}>
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-500 mb-4"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-500 mb-4"></div>
         <p>Generating scenes & visuals...</p>
       </div>
     );
@@ -303,12 +303,12 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           ) : null
         ))}
         {currentScene && isPlaying && (
-            <div className="absolute top-0 left-0 h-1 bg-fuchsia-600 transition-all duration-100 ease-linear" style={{ width: `${(elapsedTime / ((currentScene?.duration || 1) * 1000)) * 100}%` }}></div>
+            <div className="absolute top-0 left-0 h-1 bg-emerald-600 transition-all duration-100 ease-linear" style={{ width: `${(elapsedTime / ((currentScene?.duration || 1) * 1000)) * 100}%` }}></div>
         )}
       </div>
       {scenes.length > 0 && (
         <div className="mt-2 h-2 bg-gray-800 rounded-full overflow-hidden">
-          <div className="h-full bg-fuchsia-500" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
+          <div className="h-full bg-emerald-500" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
         </div>
       )}
       <div className="mt-3 flex items-center justify-between space-x-2">
@@ -316,7 +316,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           <button
             onClick={handlePlayPause}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-fuchsia-400 hover:text-fuchsia-300"
+            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-emerald-400 hover:text-emerald-300"
             aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isPlaying ? <PauseIcon className="w-5 h-5 sm:w-6 sm:h-6" /> : <PlayIcon className="w-5 h-5 sm:w-6 sm:h-6" />}
@@ -324,7 +324,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
            <button
             onClick={handleRestart}
             disabled={scenes.length === 0 || isGenerating || isDownloading}
-            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-sm text-fuchsia-400 hover:text-fuchsia-300"
+            className="p-2 rounded-full bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors text-sm text-emerald-400 hover:text-emerald-300"
             aria-label="Restart"
           >
             Restart
@@ -339,7 +339,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
         <button
           onClick={onDownloadRequest}
           disabled={scenes.length === 0 || isGenerating || isDownloading}
-          className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-fuchsia-600 hover:bg-fuchsia-500 disabled:opacity-50 text-white text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
+          className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
           aria-live="polite"
         >
           <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />


### PR DESCRIPTION
## Summary
- tweak spacing between navbar and hero
- center the mobile nav overlay
- switch accent color to emerald
- add swipeable cards on small screens
- update trend analysis copy

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fb0fed1c8832ebe0a4350eb5e1c11