### PR TITLE
Improve Disruptive Extras layout

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -89,23 +89,29 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
             <div className="absolute inset-0 bg-[linear-gradient(#4441_1px,transparent_1px),linear-gradient(90deg,#4441_1px,transparent_1px)] bg-[length:32px_32px] opacity-20 pointer-events-none" />
             <div className="absolute -inset-px rounded-2xl bg-gradient-to-br from-fuchsia-500/20 via-transparent to-transparent pointer-events-none" />
             <p className="relative z-10 text-gray-300 mb-8">Harness cutting-edge algorithms that exploit the web's volatility. These extras escalate tension and lock in engagement.</p>
-            <div className="relative z-10 grid grid-cols-1 sm:grid-cols-3 gap-8 text-center">
-              <div>
-                <div className="text-2xl font-bold text-white">+250%</div>
-                <div className="text-fuchsia-400 text-sm uppercase tracking-wide mt-1">Comment Surge</div>
-                <p className="text-gray-400 text-sm mt-2">Outrage Engine ignites minor rifts into viral showdowns.</p>
-              </div>
-              <div>
-                <div className="text-2xl font-bold text-white">&lt;30s</div>
-                <div className="text-fuchsia-400 text-sm uppercase tracking-wide mt-1">Trending Speed</div>
-                <p className="text-gray-400 text-sm mt-2">Narrative Hijacker grabs hot topics before rivals react.</p>
-              </div>
-              <div>
-                <div className="text-2xl font-bold text-white">4x</div>
-                <div className="text-fuchsia-400 text-sm uppercase tracking-wide mt-1">Return Visits</div>
-                <p className="text-gray-400 text-sm mt-2">Addiction Loop Builder keeps viewers coming back for more.</p>
-              </div>
-            </div>
+            <ul className="relative z-10 space-y-6 text-left">
+              <li className="flex flex-col sm:flex-row sm:items-center gap-4">
+                <div className="text-2xl font-bold text-white shrink-0">+250%</div>
+                <div>
+                  <div className="text-fuchsia-400 text-sm uppercase tracking-wide">Comment Surge</div>
+                  <p className="text-gray-400 text-sm mt-1">Outrage Engine ignites minor rifts into viral showdowns.</p>
+                </div>
+              </li>
+              <li className="flex flex-col sm:flex-row sm:items-center gap-4">
+                <div className="text-2xl font-bold text-white shrink-0">&lt;30s</div>
+                <div>
+                  <div className="text-fuchsia-400 text-sm uppercase tracking-wide">Trending Speed</div>
+                  <p className="text-gray-400 text-sm mt-1">Narrative Hijacker grabs hot topics before rivals react.</p>
+                </div>
+              </li>
+              <li className="flex flex-col sm:flex-row sm:items-center gap-4">
+                <div className="text-2xl font-bold text-white shrink-0">4x</div>
+                <div>
+                  <div className="text-fuchsia-400 text-sm uppercase tracking-wide">Return Visits</div>
+                  <p className="text-gray-400 text-sm mt-1">Addiction Loop Builder keeps viewers coming back for more.</p>
+                </div>
+              </li>
+            </ul>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- modernize the **Disruptive Extras** section
- switch from a 3-card grid to a clean article-style list for better mobile display

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684fc29d0b14832e885c1f303ed8df82