### PR TITLE
Enhance mobile experience

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -401,7 +401,7 @@ const App: React.FC = () => {
         </div>
 
         {previewMounted && (
-        <div className={`p-1 sm:p-2 bg-neutral-900/80 backdrop-blur-lg border border-neutral-700 rounded-xl shadow-lg transition-opacity duration-500 ${showPreview ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+        <div className={`p-1 sm:p-2 pb-20 sm:pb-2 bg-neutral-900/80 backdrop-blur-lg border border-neutral-700 rounded-xl shadow-lg transition-opacity duration-500 ${showPreview ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
            <h2 className="text-xl sm:text-2xl font-semibold mb-2 sm:mb-4 text-white px-3 py-2" style={{ fontFamily: 'Fira Code' }}>3. Preview Your Video</h2>
           <VideoPreview
             scenes={scenes}

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -51,7 +51,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </div>
         )}
       </header>
-      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 pt-24">
+      <main className="flex-1 flex flex-col items-center justify-center text-center px-4 pt-24 pb-32">
         <h2 className="text-4xl sm:text-6xl font-extrabold mb-6 bg-gradient-to-br from-fuchsia-400 to-cyan-400 bg-clip-text text-transparent">
           <TypewriterText
             phrases={[
@@ -166,6 +166,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </div>
         </section>
       </main>
+      <div className="sm:hidden fixed bottom-4 inset-x-0 flex justify-center pointer-events-none">
+        <button
+          onClick={onGetStarted}
+          className="pointer-events-auto bg-white text-black px-6 py-3 rounded-full shadow-lg"
+        >
+          Launch App
+        </button>
+      </div>
       <footer className="p-4 text-center text-gray-500 text-sm">
         <p>&copy; {new Date().getFullYear()} CineSynth. AI that disrupts filmmaking.</p>
       </footer>

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -306,12 +306,13 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
             <div className="absolute top-0 left-0 h-1 bg-white transition-all duration-100 ease-linear" style={{ width: `${(elapsedTime / ((currentScene?.duration || 1) * 1000)) * 100}%` }}></div>
         )}
       </div>
-      {scenes.length > 0 && (
-        <div className="mt-2 h-2 bg-neutral-800 rounded-full overflow-hidden">
-          <div className="h-full bg-white" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
-        </div>
-      )}
-      <div className="mt-3 flex items-center justify-between space-x-2">
+      <div className="sm:static fixed inset-x-0 bottom-0 sm:mt-3 mt-0 bg-black/80 sm:bg-transparent p-2 sm:p-0 backdrop-blur-md sm:backdrop-blur-none z-20">
+        {scenes.length > 0 && (
+          <div className="mb-2 h-2 bg-neutral-800 rounded-full overflow-hidden">
+            <div className="h-full bg-white" style={{ width: `${totalDuration > 0 ? (playedDuration / totalDuration) * 100 : 0}%`, transition: playedDuration > 0 ? 'width 0.1s linear' : 'none' }}></div>
+          </div>
+        )}
+      <div className="flex items-center justify-between space-x-2">
         <div className="flex items-center space-x-2">
           <button
             onClick={handlePlayPause}
@@ -345,6 +346,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />
           {isDownloading ? 'Rendering Video...' : 'Download Video'}
         </button>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add fixed overlay for video controls on small screens
- reserve padding in preview container
- add mobile CTA button on landing page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850109695e0832e9df9815829b4f354