### PR TITLE
Improve mobile feature cards

### DIFF
--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import FadeInSection from './FadeInSection.tsx';
+
+interface FeatureCardProps {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}
+
+const FeatureCard: React.FC<FeatureCardProps> = ({ icon: Icon, title, description }) => (
+  <FadeInSection>
+    <div className="relative p-6 bg-black/60 backdrop-blur-lg border border-gray-700 rounded-xl overflow-hidden group transition-transform duration-300 hover:scale-105 active:scale-95">
+      <div className="absolute -top-5 -right-5 w-24 h-24 bg-fuchsia-500/40 rounded-full blur-2xl opacity-0 group-hover:opacity-60 transition-opacity duration-500" />
+      <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+      <Icon className="relative z-10 w-8 h-8 text-white mb-3" />
+      <h3 className="relative z-10 font-semibold text-white group-hover:text-fuchsia-200 transition-colors duration-500">{title}</h3>
+      <p className="relative z-10 text-gray-400 group-hover:text-gray-200 text-sm mt-1 transition-colors duration-500">{description}</p>
+    </div>
+  </FadeInSection>
+);
+
+export default FeatureCard;

--- a/components/IconComponents.tsx
+++ b/components/IconComponents.tsx
@@ -73,3 +73,15 @@ export const QuoteIcon: React.FC<{ className?: string }> = ({ className }) => (
     <path d="M7.5 5C5.015 5 3 7.015 3 9.5S5.015 14 7.5 14c.047 0 .093 0 .139-.002A3.48 3.48 0 0 0 7 15.5c0 1.933 1.567 3.5 3.5 3.5V17C8.57 17 7 15.43 7 13.5c0-.646.17-1.252.469-1.777C7.316 11.745 7.167 11.5 7 11.5 5.067 11.5 3.5 9.933 3.5 8S5.067 4.5 7 4.5h.5V5Zm9 0C14.015 5 12 7.015 12 9.5s2.015 4.5 4.5 4.5c.047 0 .093 0 .139-.002A3.48 3.48 0 0 0 16 15.5c0 1.933 1.567 3.5 3.5 3.5V17c-1.93 0-3.5-1.57-3.5-3.5 0-.646.17-1.252.469-1.777.157-.478.006-.723-.163-.723-1.933 0-3.5-1.567-3.5-3.5S14.567 5 16.5 5H17v.5h-.5Z"/>
   </svg>
 );
+export const ChartIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M4 20h16M4 10h4v10H4V10zm6-4h4v14h-4V6zm6 8h4v6h-4v-6z" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+export const ShareIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg className={className} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M16 6l-4-4-4 4" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M12 2v14" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, QuoteIcon } from './IconComponents.tsx';
+import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, QuoteIcon, ChartIcon, ShareIcon } from './IconComponents.tsx';
 import TypewriterText from './TypewriterText.tsx';
+import FeatureCard from './FeatureCard.tsx';
 import FadeInSection from './FadeInSection.tsx';
 
 interface LandingPageProps {
@@ -73,34 +74,18 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           Get Started
         </button>
 
-        <div id="features" className="grid grid-cols-1 gap-4 sm:grid-cols-3 sm:gap-6 w-full max-w-4xl mt-12 mb-8 text-left px-2">
-          <FadeInSection>
-            <div className="relative p-6 bg-black/60 backdrop-blur-lg border border-gray-700 rounded-xl overflow-hidden group">
-              <div className="absolute -top-5 -right-5 w-24 h-24 bg-fuchsia-500/40 rounded-full blur-2xl opacity-0 group-hover:opacity-60 transition-opacity duration-500" />
-              <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-              <TrendingUpIcon className="relative z-10 w-8 h-8 text-white mb-3" />
-              <h3 className="relative z-10 font-semibold text-white group-hover:text-fuchsia-200 transition-colors duration-500">Trend Analysis</h3>
-              <p className="relative z-10 text-gray-400 group-hover:text-gray-200 text-sm mt-1 transition-colors duration-500">AI exposes your audience's deepest impulses so your content always hits the mark.</p>
+        <div id="features" className="w-full max-w-4xl mt-12 mb-8 text-left px-2 flex gap-4 overflow-x-auto sm:grid sm:grid-cols-3 sm:gap-6 sm:overflow-visible">
+          {[
+            { icon: TrendingUpIcon, title: 'Trend Analysis', description: "AI exposes your audience's deepest impulses so your content always hits the mark." },
+            { icon: ScissorsIcon, title: 'No Editing Required', description: 'Just talk. We handle visuals, timing and audio sync automatically.' },
+            { icon: FireIcon, title: 'Controversy Ready', description: 'Create bold videos that spark engagement without the headaches.' },
+            { icon: ChartIcon, title: 'Analytics Dashboard', description: 'Track performance and refine your strategy with built-in metrics.' },
+            { icon: ShareIcon, title: 'Share Anywhere', description: 'Optimized exports for every major social platform.' },
+          ].map((feat) => (
+            <div key={feat.title} className="min-w-[80%] sm:min-w-0">
+              <FeatureCard icon={feat.icon} title={feat.title} description={feat.description} />
             </div>
-          </FadeInSection>
-          <FadeInSection>
-            <div className="relative p-6 bg-black/60 backdrop-blur-lg border border-gray-700 rounded-xl overflow-hidden group">
-              <div className="absolute -top-5 -right-5 w-24 h-24 bg-fuchsia-500/40 rounded-full blur-2xl opacity-0 group-hover:opacity-60 transition-opacity duration-500" />
-              <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-              <ScissorsIcon className="relative z-10 w-8 h-8 text-white mb-3" />
-              <h3 className="relative z-10 font-semibold text-white group-hover:text-fuchsia-200 transition-colors duration-500">No Editing Required</h3>
-              <p className="relative z-10 text-gray-400 group-hover:text-gray-200 text-sm mt-1 transition-colors duration-500">Just talk. We handle visuals, timing and audio sync automatically.</p>
-            </div>
-          </FadeInSection>
-          <FadeInSection>
-            <div className="relative p-6 bg-black/60 backdrop-blur-lg border border-gray-700 rounded-xl overflow-hidden group">
-              <div className="absolute -top-5 -right-5 w-24 h-24 bg-fuchsia-500/40 rounded-full blur-2xl opacity-0 group-hover:opacity-60 transition-opacity duration-500" />
-              <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
-              <FireIcon className="relative z-10 w-8 h-8 text-white mb-3" />
-              <h3 className="relative z-10 font-semibold text-white group-hover:text-fuchsia-200 transition-colors duration-500">Controversy Ready</h3>
-              <p className="relative z-10 text-gray-400 group-hover:text-gray-200 text-sm mt-1 transition-colors duration-500">Create bold videos that spark engagement without the headaches.</p>
-            </div>
-          </FadeInSection>
+          ))}
         </div>
 
         <section className="w-full py-12 border-t border-gray-800 mt-8">


### PR DESCRIPTION
## Summary
- add `FeatureCard` component to simplify feature markup
- update landing page feature section with new cards and scrollable mobile layout
- add `ChartIcon` and `ShareIcon`

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685011afa374832eb3a69885f111a1a3