### PR TITLE
Fix mobile page zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>CineSynth</title>
     <meta name="description" content="CineSynth turns text into engaging video using AI." />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
## Summary
- prevent auto zooming by disabling user scaling in the viewport meta tag

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685017813280832ea38bba8052c6041f