### PR TITLE
Improve responsive defaults

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,7 +17,12 @@ import { SparklesIcon } from './components/IconComponents.tsx';
 const App: React.FC = () => {
   const [narrationText, setNarrationText] = useState<string>('');
   const [scenes, setScenes] = useState<Scene[]>([]);
-  const [aspectRatio, setAspectRatio] = useState<AspectRatio>(DEFAULT_ASPECT_RATIO);
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>(() => {
+    if (typeof window !== 'undefined') {
+      return window.innerWidth < window.innerHeight ? '9:16' : DEFAULT_ASPECT_RATIO;
+    }
+    return DEFAULT_ASPECT_RATIO;
+  });
   const [isGeneratingScenes, setIsGeneratingScenes] = useState<boolean>(false);
   const [isRenderingVideo, setIsRenderingVideo] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Automatic editing and subtitle generation
 - Optional AI‑generated imagery using Imagen
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
+- Responsive default aspect ratio adapts to device orientation
 
 ## Getting Started
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CineSynth</title>
     <meta name="description" content="CineSynth turns text into engaging video using AI." />
     <meta name="theme-color" content="#000000" />


### PR DESCRIPTION
## Summary
- loosen viewport restrictions so mobile users can zoom
- default aspect ratio now respects device orientation
- document responsive aspect ratio behavior

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68501aab380c832ea0e8c11d1e759f06