### PR TITLE
Improve landing UX and mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    npm run dev
    ```
 
+During development the app and landing page run on the same domain. Click **Get Started** on the landing page to load the main editor. When deployed, the landing page should live on your root domain with the editor served from an `app.` subdomain. This behaviour is handled automatically by the code.
+
 Development mode automatically provides the required cross-origin isolation headers so ffmpeg.wasm can use `SharedArrayBuffer`. Always run the app via `npm run dev` or `npm run preview` after building.
 
 ### Faster MP4 Conversion

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>CineSynth</title>
     <meta name="description" content="CineSynth turns text into engaging video using AI." />
     <meta name="theme-color" content="#000000" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Fira+Code:wght@400;600&display=swap" rel="stylesheet">

--- a/index.tsx
+++ b/index.tsx
@@ -1,11 +1,43 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import LandingPage from './components/LandingPage.tsx';
 
+const isAppSubdomain =
+  typeof window !== 'undefined' &&
+  (window.location.hostname.startsWith('app.') ||
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1' ||
+    window.location.hash === '#app');
+
+const redirectToSubdomain = () => {
+  if (typeof window === 'undefined') return;
+  if (
+    window.location.hostname === 'localhost' ||
+    window.location.hostname === '127.0.0.1'
+  ) {
+    window.location.hash = '#app';
+    window.location.reload();
+    return;
+  }
+
+  const hostParts = window.location.host.split('.');
+  if (hostParts[0] === 'app') return; // already there
+  if (hostParts.length > 1) {
+    hostParts[0] = 'app';
+  } else {
+    hostParts.unshift('app');
+  }
+  const newHost = hostParts.join('.');
+  const url = `${window.location.protocol}//${newHost}${window.location.pathname}`;
+  window.location.href = url;
+};
+
 const Root: React.FC = () => {
-  const [started, setStarted] = useState(false);
-  return started ? <App /> : <LandingPage onGetStarted={() => setStarted(true)} />;
+  if (isAppSubdomain) {
+    return <App />;
+  }
+  return <LandingPage onGetStarted={redirectToSubdomain} />;
 };
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
## Summary
- add mobile PWA meta tags
- redirect **Get Started** to an `app.` subdomain
- document new launch flow

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685078a4b920832e80c8d00d2b8a93e7