### PR TITLE
Add external launch URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev
@@ -48,4 +48,8 @@ When deploying to Vercel, create a `vercel.json` file so each request includes t
 ```
 
 This ensures the MP4 conversion works correctly in the hosted app.
+
+If the landing page is served separately from the full editor, provide the
+target URL in a `LAUNCH_URL` environment variable. Visitors clicking
+**Get Started** will be redirected there.
 

--- a/constants.ts
+++ b/constants.ts
@@ -16,3 +16,6 @@ export const IMAGEN_MODEL = 'imagen-3.0-generate-002';
 // Placeholder for API Key - this should be set in the environment
 export const API_KEY = process.env.API_KEY;
 export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;
+// Optional URL where the main app is hosted. If set, the landing page
+// will redirect here when users click "Get Started".
+export const LAUNCH_URL = process.env.LAUNCH_URL;

--- a/index.tsx
+++ b/index.tsx
@@ -2,10 +2,20 @@ import React, { useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import LandingPage from './components/LandingPage.tsx';
+import { LAUNCH_URL } from './constants.ts';
 
 const Root: React.FC = () => {
   const [started, setStarted] = useState(false);
-  return started ? <App /> : <LandingPage onGetStarted={() => setStarted(true)} />;
+
+  const handleGetStarted = () => {
+    if (LAUNCH_URL) {
+      window.location.href = LAUNCH_URL;
+    } else {
+      setStarted(true);
+    }
+  };
+
+  return started ? <App /> : <LandingPage onGetStarted={handleGetStarted} />;
 };
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
## Summary
- allow specifying `LAUNCH_URL` so the landing page can redirect to another domain
- update README with new environment variable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68507a351238832e84bf5f8d4a8bdca9