### PR TITLE
Set AI features as premium and remove subtitles

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,7 +7,7 @@ import VideoPreview from './components/VideoPreview.tsx';
 import ProgressBar from './components/ProgressBar.tsx';
 import SceneEditor from './components/SceneEditor.tsx'; // New Component
 import { Scene, AspectRatio, GeminiSceneResponseItem } from './types.ts';
-import { APP_TITLE, DEFAULT_ASPECT_RATIO, API_KEY } from './constants.ts';
+import { APP_TITLE, DEFAULT_ASPECT_RATIO, API_KEY, PREMIUM_ACCESS } from './constants.ts';
 import { analyzeNarrationWithGemini, generateImageWithImagen } from './services/geminiService.ts';
 import { processNarrationToScenes, fetchPlaceholderFootageUrl } from './services/videoService.ts';
 import { generateWebMFromScenes } from './services/videoRenderingService.ts';
@@ -25,10 +25,9 @@ const App: React.FC = () => {
   const [progressMessage, setProgressMessage] = useState<string>('');
   const [progressValue, setProgressValue] = useState<number>(0); 
   const [apiKeyMissing, setApiKeyMissing] = useState<boolean>(false);
-  const [includeSubtitlesOnDownload, setIncludeSubtitlesOnDownload] = useState<boolean>(true);
   const [useAiImages, setUseAiImages] = useState<boolean>(false);
 
-  const [isTTSEnabled, setIsTTSEnabled] = useState<boolean>(true);
+  const [isTTSEnabled, setIsTTSEnabled] = useState<boolean>(PREMIUM_ACCESS);
   const [ttsPlaybackStatus, setTTSPlaybackStatus] = useState<'idle' | 'playing' | 'paused' | 'ended'>('idle');
   const currentSpeechRef = useRef<SpeechSynthesisUtterance | null>(null);
   const analysisCacheRef = useRef<GeminiSceneResponseItem[] | null>(null);
@@ -188,7 +187,7 @@ const App: React.FC = () => {
       const webmBlob = await generateWebMFromScenes(
         scenes,
         aspectRatio,
-        { includeSubtitles: includeSubtitlesOnDownload },
+        { includeSubtitles: false },
         (p) => {
           setProgressValue(Math.round(p * 100));
           if (p < 0.01) {
@@ -388,13 +387,12 @@ const App: React.FC = () => {
               isGenerating={isGeneratingScenes || isRenderingVideo} 
               hasScenes={scenes.length > 0}
               narrationText={narrationText}
-              includeSubtitlesOnDownload={includeSubtitlesOnDownload}
-              onIncludeSubtitlesChange={setIncludeSubtitlesOnDownload}
               isTTSEnabled={isTTSEnabled}
               onTTSEnabledChange={toggleTTSEnabled}
               ttsSupported={typeof window.speechSynthesis !== 'undefined'}
               useAiImages={useAiImages}
               onUseAiImagesChange={setUseAiImages}
+              isPremium={PREMIUM_ACCESS}
               apiKeyMissing={apiKeyMissing}
             />
           </div>

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 **AI-Powered Video Narration Tool**
 
-CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder footage, subtitles and final video rendering right in your browser.
+CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder footage and final video rendering right in your browser.
 
 ## Features
 
 - Smart narration analysis with Google Gemini
-- Automatic editing and subtitle generation
-- Optional AI‑generated imagery using Imagen
+- Automatic scene editing and video rendering
+- AI‑generated imagery using Imagen *(premium)*
+- Text-to-speech narration preview *(premium)*
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
 
 ## Getting Started
@@ -17,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. Set `PREMIUM_ACCESS=true` to enable premium features like AI imagery and TTS. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -10,13 +10,12 @@ interface ControlsProps {
   isGenerating: boolean;
   hasScenes: boolean;
   narrationText: string; // Added to disable button if no text
-  includeSubtitlesOnDownload: boolean;
-  onIncludeSubtitlesChange: (include: boolean) => void;
   isTTSEnabled: boolean;
   onTTSEnabledChange: (enabled: boolean) => void;
   ttsSupported: boolean;
   useAiImages: boolean;
   onUseAiImagesChange: (use: boolean) => void;
+  isPremium: boolean;
   apiKeyMissing: boolean; // Added to disable generate button
 }
 
@@ -27,13 +26,12 @@ const Controls: React.FC<ControlsProps> = ({
   isGenerating,
   hasScenes,
   narrationText,
-  includeSubtitlesOnDownload,
-  onIncludeSubtitlesChange,
   isTTSEnabled,
   onTTSEnabledChange,
   ttsSupported,
   useAiImages,
   onUseAiImagesChange,
+  isPremium,
   apiKeyMissing,
 }) => {
   const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
@@ -63,34 +61,25 @@ const Controls: React.FC<ControlsProps> = ({
         </div>
       </div>
 
-      <div>
-        <label htmlFor="useAiImages" className="flex items-center text-sm font-medium text-gray-300 mb-1 cursor-pointer select-none">
-          <input
-            id="useAiImages"
-            type="checkbox"
-            checked={useAiImages}
-            onChange={(e) => onUseAiImagesChange(e.target.checked)}
-            disabled={isGenerating || apiKeyMissing}
-            className="h-4 w-4 text-white border-neutral-600 rounded focus:ring-white bg-neutral-800 mr-2 disabled:opacity-50"
-          />
-          Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
-        </label>
-      </div>
+      {isPremium ? (
+        <div>
+          <label htmlFor="useAiImages" className="flex items-center text-sm font-medium text-gray-300 mb-1 cursor-pointer select-none">
+            <input
+              id="useAiImages"
+              type="checkbox"
+              checked={useAiImages}
+              onChange={(e) => onUseAiImagesChange(e.target.checked)}
+              disabled={isGenerating || apiKeyMissing}
+              className="h-4 w-4 text-white border-neutral-600 rounded focus:ring-white bg-neutral-800 mr-2 disabled:opacity-50"
+            />
+            Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
+          </label>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">AI-Generated Images are a premium feature.</p>
+      )}
 
-      <div>
-        <label htmlFor="includeSubtitles" className="flex items-center text-sm font-medium text-gray-300 mb-1 cursor-pointer select-none">
-          <input
-            id="includeSubtitles"
-            type="checkbox"
-            checked={includeSubtitlesOnDownload}
-            onChange={(e) => onIncludeSubtitlesChange(e.target.checked)}
-            disabled={isGenerating}
-            className="h-4 w-4 text-white border-neutral-600 rounded focus:ring-white bg-neutral-800 mr-2 disabled:opacity-50"
-          />
-          Include subtitles in download
-        </label>
-      </div>
-       {ttsSupported && (
+      {isPremium && ttsSupported && (
         <div>
           <label htmlFor="enableTTS" className="flex items-center text-sm font-medium text-gray-300 cursor-pointer select-none">
             <input
@@ -104,7 +93,7 @@ const Controls: React.FC<ControlsProps> = ({
             Enable TTS Narration (Preview)
           </label>
         </div>
-       )}
+      )}
 
       <button
         onClick={onGenerate}
@@ -118,9 +107,9 @@ const Controls: React.FC<ControlsProps> = ({
         <SparklesIcon className={`w-5 h-5 mr-2 ${isGenerating ? 'animate-spin' : ''}`} />
         {isGenerating ? 'Generating Video...' : (hasScenes ? 'Re-Generate Video from Narration' : 'Generate Video')}
       </button>
-       {!ttsSupported && (
-         <p className="text-xs text-gray-500 text-center mt-2">TTS narration not supported by your browser.</p>
-       )}
+      {isPremium && !ttsSupported && (
+        <p className="text-xs text-gray-500 text-center mt-2">TTS narration not supported by your browser.</p>
+      )}
        {apiKeyMissing && (
          <p className="text-xs text-red-400 text-center mt-2">AI features disabled: API Key missing.</p>
        )}

--- a/constants.ts
+++ b/constants.ts
@@ -19,3 +19,5 @@ export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;
 // Optional URL where the main app is hosted. If set, the landing page
 // will redirect here when users click "Get Started".
 export const LAUNCH_URL = process.env.LAUNCH_URL;
+// Flag for enabling premium-only features like AI imagery and TTS
+export const PREMIUM_ACCESS = process.env.PREMIUM_ACCESS === 'true';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig(({ mode }) => {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY)
+        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY),
+        'process.env.PREMIUM_ACCESS': JSON.stringify(env.PREMIUM_ACCESS)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- add `PREMIUM_ACCESS` environment flag
- hide AI image and TTS controls unless premium enabled
- remove subtitle download option
- update README for new premium features

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507f4b3564832eba839fc7c1c94e0c