### PR TITLE
Implement Google login and generation limits

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,8 @@ import { generateWebMFromScenes } from './services/videoRenderingService.ts';
 import { convertWebMToMP4 } from './services/mp4ConversionService.ts';
 import { generateAIVideo } from './services/aiVideoGenerationService.ts';
 import { SparklesIcon } from './components/IconComponents.tsx';
+import GoogleLoginButton from './components/GoogleLoginButton.tsx';
+import { getRemainingGenerations, recordGeneration } from './services/usageService.ts';
 
 const premiumUser = IS_PREMIUM_USER;
 
@@ -31,6 +33,10 @@ const App: React.FC = () => {
   const [includeWatermark, setIncludeWatermark] = useState<boolean>(false);
   const [useAiImages, setUseAiImages] = useState<boolean>(false);
   const [useAiVideo, setUseAiVideo] = useState<boolean>(false);
+  const [user, setUser] = useState<{ name: string } | null>(null);
+
+  const handleLogin = (u: { name: string }) => setUser(u);
+  const handleLogout = () => setUser(null);
 
   const [isTTSEnabled, setIsTTSEnabled] = useState<boolean>(premiumUser);
   const [ttsPlaybackStatus, setTTSPlaybackStatus] = useState<'idle' | 'playing' | 'paused' | 'ended'>('idle');
@@ -39,6 +45,7 @@ const App: React.FC = () => {
 
   const showPreview = scenes.length > 0 || isGeneratingScenes || isRenderingVideo;
   const [previewMounted, setPreviewMounted] = useState(showPreview);
+  const remainingGenerations = getRemainingGenerations(!!user);
 
   useEffect(() => {
     if (showPreview) {
@@ -122,6 +129,13 @@ const App: React.FC = () => {
        setError("Cannot generate video: Gemini API Key is missing.");
        return;
     }
+    const remaining = getRemainingGenerations(!!user);
+    if (remaining <= 0) {
+       setError(user ?
+         'Daily video generation limit of 5 reached.' :
+         'Daily video generation limit of 2 reached. Sign in with Google for more.');
+       return;
+    }
 
     if (useAiVideo) {
       setIsRenderingVideo(true);
@@ -140,6 +154,7 @@ const App: React.FC = () => {
         URL.revokeObjectURL(url);
         setProgressMessage('AI video downloaded!');
         setProgressValue(100);
+        recordGeneration();
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to generate AI video.';
         setError(msg);
@@ -179,6 +194,7 @@ const App: React.FC = () => {
       
       handleSceneGenerationProgress('Video preview ready!', 1, 'finalizing');
       setScenes(processedScenes);
+      recordGeneration();
       
       setTimeout(() => {
           setProgressMessage('');
@@ -373,7 +389,10 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-black text-white flex flex-col items-center p-4 sm:p-6 lg:p-8">
-      <header className="mb-6 sm:mb-8 text-center">
+      <header className="mb-6 sm:mb-8 text-center relative">
+        <div className="absolute top-0 right-0">
+          <GoogleLoginButton user={user} onLogin={handleLogin} onLogout={handleLogout} />
+        </div>
         <div className="flex items-center justify-center space-x-3">
            <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-white" />
            <h1
@@ -387,6 +406,7 @@ const App: React.FC = () => {
         <p className="mt-2 text-base sm:text-lg text-gray-400">
           Transform text into videos with AI-powered visuals and spoken narration.
         </p>
+        <p className="mt-1 text-sm text-gray-400">Remaining videos today: {remainingGenerations}</p>
       </header>
 
       {apiKeyMissing && (
@@ -432,6 +452,7 @@ const App: React.FC = () => {
               onUseAiVideoChange={setUseAiVideo}
               apiKeyMissing={apiKeyMissing}
               isPremiumUser={premiumUser}
+              generationLimitReached={remainingGenerations === 0}
             />
           </div>
         </div>

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -21,6 +21,7 @@ interface ControlsProps {
   onUseAiVideoChange: (use: boolean) => void;
   apiKeyMissing: boolean; // Added to disable generate button
   isPremiumUser: boolean;
+  generationLimitReached?: boolean;
 }
 
 const Controls: React.FC<ControlsProps> = ({
@@ -41,8 +42,9 @@ const Controls: React.FC<ControlsProps> = ({
   onUseAiVideoChange,
   apiKeyMissing,
   isPremiumUser,
+  generationLimitReached = false,
 }) => {
-  const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing;
+  const canGenerate = !isGenerating && narrationText.trim() !== '' && !apiKeyMissing && !generationLimitReached;
 
   return (
     <div className="p-4 bg-neutral-900 border border-neutral-700 rounded-lg shadow-lg space-y-6">
@@ -141,10 +143,13 @@ const Controls: React.FC<ControlsProps> = ({
         <SparklesIcon className={`w-5 h-5 mr-2 ${isGenerating ? 'animate-spin' : ''}`} />
         {isGenerating ? 'Generating Video...' : (hasScenes ? 'Re-Generate Video from Narration' : 'Generate Video')}
       </button>
-       {!ttsSupported && (
-         <p className="text-xs text-gray-500 text-center mt-2">TTS narration not supported by your browser.</p>
-       )}
-       {apiKeyMissing && (
+      {generationLimitReached && (
+        <p className="text-xs text-red-400 text-center mt-2">Daily generation limit reached.</p>
+      )}
+      {!ttsSupported && (
+        <p className="text-xs text-gray-500 text-center mt-2">TTS narration not supported by your browser.</p>
+      )}
+      {apiKeyMissing && (
          <p className="text-xs text-red-400 text-center mt-2">AI features disabled: API Key missing.</p>
        )}
     </div>

--- a/components/GoogleLoginButton.tsx
+++ b/components/GoogleLoginButton.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react';
+import { GOOGLE_CLIENT_ID } from '../constants.ts';
+
+declare global {
+  interface Window {
+    google?: any;
+  }
+}
+
+interface GoogleLoginButtonProps {
+  user: { name: string } | null;
+  onLogin: (user: { name: string }) => void;
+  onLogout: () => void;
+}
+
+const parseJwt = (token: string): any => {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return {};
+  }
+};
+
+const GoogleLoginButton: React.FC<GoogleLoginButtonProps> = ({ user, onLogin, onLogout }) => {
+  useEffect(() => {
+    if (!GOOGLE_CLIENT_ID || !window.google?.accounts?.id) return;
+    window.google.accounts.id.initialize({
+      client_id: GOOGLE_CLIENT_ID,
+      callback: (resp: any) => {
+        const info = parseJwt(resp.credential);
+        if (info && info.name) {
+          onLogin({ name: info.name });
+        }
+      },
+    });
+  }, []);
+
+  const handleSignIn = () => {
+    if (window.google?.accounts?.id) {
+      window.google.accounts.id.prompt();
+    }
+  };
+
+  const handleLogout = () => {
+    onLogout();
+    window.google?.accounts.id.disableAutoSelect?.();
+  };
+
+  return user ? (
+    <div className="flex items-center space-x-2 text-sm">
+      <span>{user.name}</span>
+      <button onClick={handleLogout} className="px-2 py-1 bg-gray-700 rounded">Logout</button>
+    </div>
+  ) : (
+    <button onClick={handleSignIn} className="px-3 py-1 bg-white text-black text-sm rounded">
+      Sign in with Google
+    </button>
+  );
+};
+
+export default GoogleLoginButton;

--- a/constants.ts
+++ b/constants.ts
@@ -19,6 +19,7 @@ export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;
 // Optional URL where the main app is hosted. If set, the landing page
 // will redirect here when users click "Get Started".
 export const LAUNCH_URL = process.env.LAUNCH_URL;
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
 
 // Premium features
 export const IS_PREMIUM_USER = process.env.IS_PREMIUM_USER === 'true';

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Fira+Code:wght@400;600&display=swap" rel="stylesheet">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script type="module" src="/tailwind.js"></script>
     <style>
       /* Custom scrollbar for a more modern look */

--- a/services/usageService.ts
+++ b/services/usageService.ts
@@ -1,0 +1,41 @@
+export const ANON_DAILY_LIMIT = 2;
+export const GOOGLE_DAILY_LIMIT = 5;
+const STORAGE_KEY = 'videoGenerationUsage';
+
+interface UsageData {
+  date: string;
+  count: number;
+}
+
+const loadData = (): UsageData => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as UsageData;
+  } catch {
+    // ignore parse errors
+  }
+  return { date: new Date().toDateString(), count: 0 };
+};
+
+export const getRemainingGenerations = (loggedIn: boolean): number => {
+  const limit = loggedIn ? GOOGLE_DAILY_LIMIT : ANON_DAILY_LIMIT;
+  const data = loadData();
+  const today = new Date().toDateString();
+  if (data.date !== today) return limit;
+  return Math.max(0, limit - data.count);
+};
+
+export const recordGeneration = (): void => {
+  const today = new Date().toDateString();
+  const data = loadData();
+  if (data.date !== today) {
+    data.date = today;
+    data.count = 0;
+  }
+  data.count += 1;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    // ignore storage errors
+  }
+};


### PR DESCRIPTION
## Summary
- add Google client ID constant
- load Google login script in `index.html`
- implement Google login component
- track daily video generation counts per user
- show login button and remaining quota in the UI
- prevent video generation if the daily limit is exceeded

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850ed427f54832e92c2a36243e3def8