### PR TITLE
Add Google login and daily limits

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 
 // Timestamp: 2024-09-12T10:00:00Z - Refresh
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useRef, useContext } from 'react';
 import TextInputArea from './components/TextInputArea.tsx';
 import Controls from './components/Controls.tsx';
 import VideoPreview from './components/VideoPreview.tsx';
@@ -8,6 +8,8 @@ import ProgressBar from './components/ProgressBar.tsx';
 import SceneEditor from './components/SceneEditor.tsx'; // New Component
 import { Scene, AspectRatio, GeminiSceneResponseItem } from './types.ts';
 import { APP_TITLE, DEFAULT_ASPECT_RATIO, API_KEY, IS_PREMIUM_USER } from './constants.ts';
+import { AuthContext } from './contexts/AuthContext.tsx';
+import { incrementUsage, remainingQuota } from './services/usageLimitService.ts';
 import { analyzeNarrationWithGemini, generateImageWithImagen } from './services/geminiService.ts';
 import { processNarrationToScenes, fetchPlaceholderFootageUrl } from './services/videoService.ts';
 import { generateWebMFromScenes } from './services/videoRenderingService.ts';
@@ -18,6 +20,9 @@ import { SparklesIcon } from './components/IconComponents.tsx';
 const premiumUser = IS_PREMIUM_USER;
 
 const App: React.FC = () => {
+  const { user } = useContext(AuthContext);
+  const dailyLimit = user ? 5 : 2;
+  const [remaining, setRemaining] = useState<number>(remainingQuota(dailyLimit));
   const [narrationText, setNarrationText] = useState<string>('');
   const [scenes, setScenes] = useState<Scene[]>([]);
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>(DEFAULT_ASPECT_RATIO);
@@ -36,6 +41,10 @@ const App: React.FC = () => {
   const [ttsPlaybackStatus, setTTSPlaybackStatus] = useState<'idle' | 'playing' | 'paused' | 'ended'>('idle');
   const currentSpeechRef = useRef<SpeechSynthesisUtterance | null>(null);
   const analysisCacheRef = useRef<GeminiSceneResponseItem[] | null>(null);
+
+  useEffect(() => {
+    setRemaining(remainingQuota(dailyLimit));
+  }, [dailyLimit]);
 
   const showPreview = scenes.length > 0 || isGeneratingScenes || isRenderingVideo;
   const [previewMounted, setPreviewMounted] = useState(showPreview);
@@ -114,6 +123,10 @@ const App: React.FC = () => {
 
 
   const handleGenerateVideo = useCallback(async () => {
+    if (remainingQuota(dailyLimit) <= 0) {
+      setError(`Daily video limit reached (${dailyLimit} per day).`);
+      return;
+    }
     if (!narrationText.trim()) {
       setError("Please enter some narration text.");
       return;
@@ -140,6 +153,8 @@ const App: React.FC = () => {
         URL.revokeObjectURL(url);
         setProgressMessage('AI video downloaded!');
         setProgressValue(100);
+        incrementUsage();
+        setRemaining(remainingQuota(dailyLimit));
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to generate AI video.';
         setError(msg);
@@ -201,6 +216,10 @@ const App: React.FC = () => {
     if (scenes.length === 0 || isRenderingVideo) {
       return;
     }
+    if (remainingQuota(dailyLimit) <= 0) {
+      setError(`Daily video limit reached (${dailyLimit} per day).`);
+      return;
+    }
     setIsRenderingVideo(true);
     setError(null);
     setWarnings([]);
@@ -256,6 +275,8 @@ const App: React.FC = () => {
       URL.revokeObjectURL(url);
       setProgressMessage('Video downloaded!');
       setProgressValue(100);
+      incrementUsage();
+      setRemaining(remainingQuota(dailyLimit));
 
       setTimeout(() => {
           setProgressMessage('');
@@ -433,6 +454,7 @@ const App: React.FC = () => {
               apiKeyMissing={apiKeyMissing}
               isPremiumUser={premiumUser}
             />
+            <p className="text-xs text-gray-400 mt-2">Remaining renders today: {remaining}/{dailyLimit}</p>
           </div>
         </div>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. Set `GOOGLE_CLIENT_ID` to enable Google login. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev
@@ -53,4 +53,6 @@ This ensures the MP4 conversion works correctly in the hosted app.
 If the landing page is served separately from the full editor, provide the
 target URL in a `LAUNCH_URL` environment variable. Visitors clicking
 **Get Started** will be redirected there.
+
+The app tracks the number of video renders per day. Anonymous users can render up to **2** videos daily, while Google‑authenticated users may render up to **5**.
 

--- a/components/GoogleLoginButton.tsx
+++ b/components/GoogleLoginButton.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { AuthContext } from '../contexts/AuthContext.tsx';
+
+const GoogleLoginButton: React.FC = () => {
+  const { user, login, logout } = useContext(AuthContext);
+
+  return user ? (
+    <button onClick={logout} className="bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-500">
+      Logout ({user.name})
+    </button>
+  ) : (
+    <button onClick={login} className="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-500">
+      Sign in with Google
+    </button>
+  );
+};
+
+export default GoogleLoginButton;

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, QuoteIcon } from './IconComponents.tsx';
+import GoogleLoginButton from './GoogleLoginButton.tsx';
 import TypewriterText from './TypewriterText.tsx';
 import FadeInSection from './FadeInSection.tsx';
 
@@ -22,6 +23,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </h1>
           <div className="hidden sm:flex items-center gap-6">
             <a href="#features" className="hover:text-gray-300 transition-colors">Features</a>
+            <GoogleLoginButton />
             <button
               className="bg-white text-black px-4 py-2 rounded-md shadow-lg hover:bg-gray-200"
               onClick={onGetStarted}
@@ -37,13 +39,14 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </button>
         </nav>
         {menuOpen && (
-          <div className="sm:hidden fixed inset-0 bg-black/90 backdrop-blur flex flex-col items-center justify-center space-y-6 z-50 min-h-screen">
-            <a href="#features" className="text-2xl" onClick={() => setMenuOpen(false)}>Features</a>
-            <button
-              className="bg-white text-black px-6 py-3 rounded-md text-lg shadow-lg hover:bg-gray-200"
-              onClick={() => { setMenuOpen(false); onGetStarted(); }}
-            >
-              Launch App
+        <div className="sm:hidden fixed inset-0 bg-black/90 backdrop-blur flex flex-col items-center justify-center space-y-6 z-50 min-h-screen">
+          <a href="#features" className="text-2xl" onClick={() => setMenuOpen(false)}>Features</a>
+          <GoogleLoginButton />
+          <button
+            className="bg-white text-black px-6 py-3 rounded-md text-lg shadow-lg hover:bg-gray-200"
+            onClick={() => { setMenuOpen(false); onGetStarted(); }}
+          >
+            Launch App
             </button>
             <button className="absolute top-4 right-4 p-2" onClick={() => setMenuOpen(false)}>
               <CloseIcon className="w-6 h-6" />

--- a/constants.ts
+++ b/constants.ts
@@ -23,3 +23,4 @@ export const LAUNCH_URL = process.env.LAUNCH_URL;
 // Premium features
 export const IS_PREMIUM_USER = process.env.IS_PREMIUM_USER === 'true';
 export const WATERMARK_TEXT = 'CineSynth';
+export const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useEffect, useState, ReactNode } from 'react';
+import { GOOGLE_CLIENT_ID } from '../constants.ts';
+
+interface User {
+  name: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  login: () => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextType>({
+  user: null,
+  login: () => {},
+  logout: () => {},
+});
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('authUser');
+    if (saved) {
+      try {
+        setUser(JSON.parse(saved));
+      } catch {
+        localStorage.removeItem('authUser');
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      localStorage.setItem('authUser', JSON.stringify(user));
+    } else {
+      localStorage.removeItem('authUser');
+    }
+  }, [user]);
+
+  const login = () => {
+    const google = (window as any).google;
+    if (google?.accounts?.id && GOOGLE_CLIENT_ID) {
+      google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: (resp: any) => {
+          try {
+            const payload = JSON.parse(atob(resp.credential.split('.')[1]));
+            setUser({ name: payload.name });
+          } catch {
+            console.error('Failed to parse Google token');
+          }
+        },
+      });
+      google.accounts.id.prompt();
+    }
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       }
 
       body.dynamic-bg {
-        background: linear-gradient(45deg, #000, #111, #000);
+        background: linear-gradient(45deg, #312e81, #6b21a8, #312e81);
         background-size: 400% 400%;
         animation: bgShift 20s ease infinite;
       }
@@ -92,9 +92,10 @@
   }
 }
 </script>
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
   <!-- WebM Writer library removed -->
 </head>
-  <body class="bg-gradient-to-br from-neutral-900 via-neutral-800 to-black text-white antialiased dynamic-bg" style="font-family: 'Sora', sans-serif;">
+  <body class="bg-gradient-to-br from-indigo-900 via-purple-900 to-black text-white antialiased dynamic-bg" style="font-family: 'Sora', sans-serif;">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import LandingPage from './components/LandingPage.tsx';
 import { LAUNCH_URL } from './constants.ts';
+import { AuthProvider } from './contexts/AuthContext.tsx';
 
 const Root: React.FC = () => {
   const [started, setStarted] = useState(false);
@@ -26,6 +27,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <Root />
+    <AuthProvider>
+      <Root />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/services/usageLimitService.ts
+++ b/services/usageLimitService.ts
@@ -1,0 +1,33 @@
+export interface UsageInfo {
+  date: string;
+  count: number;
+}
+
+const STORAGE_KEY = 'videoGenUsage';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+export const getUsageInfo = (): UsageInfo => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as UsageInfo;
+      if (parsed.date === today()) return parsed;
+    } catch {
+      /* ignore */
+    }
+  }
+  return { date: today(), count: 0 };
+};
+
+export const incrementUsage = () => {
+  const info = getUsageInfo();
+  const updated = { date: today(), count: info.count + 1 };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+};
+
+export const remainingQuota = (limit: number) => {
+  const info = getUsageInfo();
+  if (info.date !== today()) return limit;
+  return Math.max(0, limit - info.count);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig(({ mode }) => {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY)
+        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY),
+        'process.env.GOOGLE_CLIENT_ID': JSON.stringify(env.GOOGLE_CLIENT_ID)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- integrate Google Sign-In with new Auth context
- set daily render limits (2 anonymous, 5 signed-in)
- display remaining quota in app
- revamp landing page colors and include login buttons
- document new GOOGLE_CLIENT_ID env and limits

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850ef942404832e952e64a915610807