### PR TITLE
Add Google login and premium option

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,6 +8,8 @@ import ProgressBar from './components/ProgressBar.tsx';
 import SceneEditor from './components/SceneEditor.tsx'; // New Component
 import { Scene, AspectRatio, GeminiSceneResponseItem } from './types.ts';
 import { APP_TITLE, DEFAULT_ASPECT_RATIO, API_KEY, IS_PREMIUM_USER } from './constants.ts';
+import LoginButton from './components/LoginButton.tsx';
+import { useAuth } from './auth/AuthContext.tsx';
 import { analyzeNarrationWithGemini, generateImageWithImagen } from './services/geminiService.ts';
 import { processNarrationToScenes, fetchPlaceholderFootageUrl } from './services/videoService.ts';
 import { generateWebMFromScenes } from './services/videoRenderingService.ts';
@@ -15,9 +17,10 @@ import { convertWebMToMP4 } from './services/mp4ConversionService.ts';
 import { generateAIVideo } from './services/aiVideoGenerationService.ts';
 import { SparklesIcon } from './components/IconComponents.tsx';
 
-const premiumUser = IS_PREMIUM_USER;
 
 const App: React.FC = () => {
+  const { isPremium } = useAuth();
+  const premiumUser = IS_PREMIUM_USER || isPremium;
   const [narrationText, setNarrationText] = useState<string>('');
   const [scenes, setScenes] = useState<Scene[]>([]);
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>(DEFAULT_ASPECT_RATIO);
@@ -68,6 +71,12 @@ const App: React.FC = () => {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (!premiumUser) {
+      setIsTTSEnabled(false);
+    }
+  }, [premiumUser]);
 
   const addWarning = useCallback((message: string) => {
     setWarnings(prev => [...prev, message]);
@@ -373,7 +382,8 @@ const App: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-black text-white flex flex-col items-center p-4 sm:p-6 lg:p-8">
-      <header className="mb-6 sm:mb-8 text-center">
+      <header className="mb-6 sm:mb-8 text-center relative">
+        <div className="absolute top-0 right-0"><LoginButton /></div>
         <div className="flex items-center justify-center space-x-3">
            <SparklesIcon className="w-8 h-8 sm:w-10 sm:h-10 text-white" />
            <h1

--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import jwt_decode from 'jwt-decode';
+
+interface User {
+  name: string;
+  email: string;
+  picture?: string;
+}
+
+interface AuthContextProps {
+  user: User | null;
+  isPremium: boolean;
+  signIn: () => void;
+  signOut: () => void;
+  activatePremium: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [isPremium, setIsPremium] = useState(false);
+
+  useEffect(() => {
+    const storedUser = localStorage.getItem('auth_user');
+    const storedPremium = localStorage.getItem('premium_user');
+    if (storedUser) setUser(JSON.parse(storedUser));
+    if (storedPremium === 'true') setIsPremium(true);
+  }, []);
+
+  const signIn = () => {
+    // @ts-ignore
+    if (!window.google || !import.meta.env.VITE_GOOGLE_CLIENT_ID) {
+      console.error('Google client ID missing');
+      return;
+    }
+    // @ts-ignore
+    window.google.accounts.id.initialize({
+      client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
+      callback: (resp: any) => {
+        if (resp.credential) {
+          const info: any = jwt_decode(resp.credential);
+          const newUser: User = { name: info.name, email: info.email, picture: info.picture };
+          setUser(newUser);
+          localStorage.setItem('auth_user', JSON.stringify(newUser));
+        }
+      },
+    });
+    // @ts-ignore
+    window.google.accounts.id.prompt();
+  };
+
+  const signOut = () => {
+    setUser(null);
+    setIsPremium(false);
+    localStorage.removeItem('auth_user');
+    localStorage.removeItem('premium_user');
+  };
+
+  const activatePremium = () => {
+    setIsPremium(true);
+    localStorage.setItem('premium_user', 'true');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, isPremium, signIn, signOut, activatePremium }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { SparklesIcon, MenuIcon, CloseIcon, TrendingUpIcon, ScissorsIcon, FireIcon, QuoteIcon } from './IconComponents.tsx';
+import LoginButton from './LoginButton.tsx';
 import TypewriterText from './TypewriterText.tsx';
 import FadeInSection from './FadeInSection.tsx';
 
@@ -22,6 +23,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
           </h1>
           <div className="hidden sm:flex items-center gap-6">
             <a href="#features" className="hover:text-gray-300 transition-colors">Features</a>
+            <LoginButton />
             <button
               className="bg-white text-black px-4 py-2 rounded-md shadow-lg hover:bg-gray-200"
               onClick={onGetStarted}
@@ -39,6 +41,7 @@ const LandingPage: React.FC<LandingPageProps> = ({ onGetStarted }) => {
         {menuOpen && (
           <div className="sm:hidden fixed inset-0 bg-black/90 backdrop-blur flex flex-col items-center justify-center space-y-6 z-50 min-h-screen">
             <a href="#features" className="text-2xl" onClick={() => setMenuOpen(false)}>Features</a>
+            <LoginButton />
             <button
               className="bg-white text-black px-6 py-3 rounded-md text-lg shadow-lg hover:bg-gray-200"
               onClick={() => { setMenuOpen(false); onGetStarted(); }}

--- a/components/LoginButton.tsx
+++ b/components/LoginButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useAuth } from '../auth/AuthContext.tsx';
+
+const LoginButton: React.FC = () => {
+  const { user, signIn, signOut, isPremium, activatePremium } = useAuth();
+
+  if (user) {
+    return (
+      <div className="flex items-center space-x-2 text-sm">
+        {user.picture && <img src={user.picture} className="w-6 h-6 rounded-full" alt="avatar" />}
+        <span>{user.name}{isPremium ? ' (Premium)' : ''}</span>
+        {!isPremium && (
+          <button
+            onClick={activatePremium}
+            className="px-2 py-1 bg-yellow-500 text-black rounded-md text-xs"
+          >
+            Activate Premium
+          </button>
+        )}
+        <button onClick={signOut} className="text-red-400 text-xs">Sign Out</button>
+      </div>
+    );
+  }
+
+  return (
+    <button onClick={signIn} className="text-sm hover:text-gray-300">
+      Sign In with Google
+    </button>
+  );
+};
+
+export default LoginButton;

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
     <script type="module" src="/tailwind.js"></script>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <style>
       /* Custom scrollbar for a more modern look */
       ::-webkit-scrollbar {

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import LandingPage from './components/LandingPage.tsx';
 import { LAUNCH_URL } from './constants.ts';
+import { AuthProvider } from './auth/AuthContext.tsx';
 
 const Root: React.FC = () => {
   const [started, setStarted] = useState(false);
@@ -26,6 +27,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <Root />
+    <AuthProvider>
+      <Root />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ffmpeg/util": "^0.12.2",
         "@google/genai": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "jwt-decode": "^3.1.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1638,6 +1639,12 @@
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ffmpeg/util": "^0.12.2",
     "@google/genai": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "jwt-decode": "^3.1.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
## Summary
- add Google Identity Services script
- implement `AuthContext` with local storage
- add `LoginButton` with ability to sign in and activate premium
- wrap app with `AuthProvider`
- show login button in app header and landing page
- update premium checks to respect login status
- include `jwt-decode` dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850f3dc7b48832e8d6cb964f9a36b57