### PR TITLE
Add placeholder video option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. Set `USE_VIDEO_PLACEHOLDERS=true` to use short stock videos instead of photos. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/components/Controls.tsx
+++ b/components/Controls.tsx
@@ -19,6 +19,8 @@ interface ControlsProps {
   onUseAiImagesChange: (use: boolean) => void;
   useAiVideo: boolean;
   onUseAiVideoChange: (use: boolean) => void;
+  useVideoPlaceholders: boolean;
+  onUseVideoPlaceholdersChange: (use: boolean) => void;
   apiKeyMissing: boolean; // Added to disable generate button
   isPremiumUser: boolean;
 }
@@ -39,6 +41,8 @@ const Controls: React.FC<ControlsProps> = ({
   onUseAiImagesChange,
   useAiVideo,
   onUseAiVideoChange,
+  useVideoPlaceholders,
+  onUseVideoPlaceholdersChange,
   apiKeyMissing,
   isPremiumUser,
 }) => {
@@ -81,6 +85,20 @@ const Controls: React.FC<ControlsProps> = ({
           />
           Use AI-Generated Images <span className="text-xs text-gray-400 ml-1">(Slower, uses more quota)</span>
           {!isPremiumUser && <span className="ml-1 text-xs text-yellow-400">(Premium)</span>}
+        </label>
+      </div>
+
+      <div>
+        <label htmlFor="useVideoPlaceholders" className="flex items-center text-sm font-medium text-gray-300 mb-1 cursor-pointer select-none">
+          <input
+            id="useVideoPlaceholders"
+            type="checkbox"
+            checked={useVideoPlaceholders}
+            onChange={(e) => onUseVideoPlaceholdersChange(e.target.checked)}
+            disabled={isGenerating}
+            className="h-4 w-4 text-white border-neutral-600 rounded focus:ring-white bg-neutral-800 mr-2 disabled:opacity-50"
+          />
+          Use Placeholder Videos
         </label>
       </div>
 

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -112,12 +112,14 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 </p>
                 <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
                 <p className="text-gray-300 text-sm truncate">
-                    <strong className="text-gray-400">Image:</strong> {
-                        scene.footageUrl.startsWith('data:image') ? 
-                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 
-                        'Placeholder'
+                    <strong className="text-gray-400">Media:</strong> {
+                        scene.isVideo ? 'Video Placeholder' : (
+                          scene.footageUrl.startsWith('data:image') ?
+                            (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') :
+                            'Placeholder'
+                        )
                     }
-                    {scene.footageUrl.startsWith('data:image') && scene.imagePrompt && 
+                    {!scene.isVideo && scene.footageUrl.startsWith('data:image') && scene.imagePrompt &&
                      <span className="text-xs text-gray-500 italic ml-1">(Prompt: {scene.imagePrompt.substring(0,30)}...)</span>
                     }
                 </p>

--- a/constants.ts
+++ b/constants.ts
@@ -16,6 +16,7 @@ export const IMAGEN_MODEL = 'imagen-3.0-generate-002';
 // Placeholder for API Key - this should be set in the environment
 export const API_KEY = process.env.API_KEY;
 export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;
+export const USE_VIDEO_PLACEHOLDERS = process.env.USE_VIDEO_PLACEHOLDERS === 'true';
 // Optional URL where the main app is hosted. If set, the landing page
 // will redirect here when users click "Get Started".
 export const LAUNCH_URL = process.env.LAUNCH_URL;

--- a/types.ts
+++ b/types.ts
@@ -14,7 +14,8 @@ export interface Scene {
   keywords: string[];
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
-  footageUrl: string; // URL to image (can be base64 data URL)
+  footageUrl: string; // URL to image or video (can be base64 data URL)
+  isVideo?: boolean; // true if footageUrl points to a video
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- introduce `USE_VIDEO_PLACEHOLDERS` env flag
- add placeholder video fetch logic
- show videos in preview if enabled
- expose toggle in controls and scene editor
- update README with new env variable

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854297a47a0832e9ef98761ed5b8048