### PR TITLE
Switch to Pexels video placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **AI-Powered Video Narration Tool**
 
-CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder footage, subtitles and final video rendering right in your browser.
+CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder video clips, subtitles and final video rendering right in your browser.
 
 ## Features
 
@@ -18,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder videos. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "CineSynth",
-  "description": "An AI-powered web application that transforms text narrations into engaging videos. Features placeholder visuals for each scene based on keywords, subtitles, and a Text-to-Speech (TTS) narration preview. Users input narration, and the system handles scene segmentation, keyword extraction for placeholder images, subtitle creation, and video assembly for preview and WebM download.",
+  "description": "An AI-powered web application that transforms text narrations into engaging videos. Features placeholder video clips for each scene based on keywords, subtitles, and a Text-to-Speech (TTS) narration preview. Users input narration, and the system handles scene segmentation, keyword extraction for placeholder videos, subtitle creation, and video assembly for preview and WebM download.",
   "requestFramePermissions": [],
   "prompt": ""
 }

--- a/types.ts
+++ b/types.ts
@@ -14,7 +14,8 @@ export interface Scene {
   keywords: string[];
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
-  footageUrl: string; // URL to image (can be base64 data URL)
+  footageUrl: string; // URL to image or video
+  footageType?: 'image' | 'video';
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- pull placeholder footage from Pexels videos instead of photos
- support video placeholders in scene processing
- update preview player to cross‑fade video clips
- adjust rendering service to draw video frames
- update docs and metadata

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685430b230d4832eaf2de2991f2a9358