### PR TITLE
Use Pexels videos for placeholder footage

### DIFF
--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -29,7 +29,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
   const [editableSceneId, setEditableSceneId] = useState<string | null>(null);
   const [editText, setEditText] = useState<string>('');
   const [editDuration, setEditDuration] = useState<number>(0);
-  const [isUpdatingImage, setIsUpdatingImage] = useState<string | null>(null); // Store ID of scene whose image is updating
+  const [isUpdatingImage, setIsUpdatingImage] = useState<string | null>(null); // Store ID of scene whose footage is updating
 
   const handleEdit = (scene: Scene) => {
     setEditableSceneId(scene.id);
@@ -42,7 +42,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
     setEditableSceneId(null);
   };
 
-  const handleImageUpdate = async (sceneId: string) => {
+  const handleFootageUpdate = async (sceneId: string) => {
     setIsUpdatingImage(sceneId);
     try {
       await onUpdateSceneImage(sceneId);
@@ -112,12 +112,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 </p>
                 <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
                 <p className="text-gray-300 text-sm truncate">
-                    <strong className="text-gray-400">Image:</strong> {
-                        scene.footageUrl.startsWith('data:image') ? 
-                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 
-                        'Placeholder'
+                    <strong className="text-gray-400">Footage:</strong> {
+                        scene.footageType === 'image' ?
+                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') :
+                        'Placeholder Video'
                     }
-                    {scene.footageUrl.startsWith('data:image') && scene.imagePrompt && 
+                    {scene.footageType === 'image' && scene.imagePrompt &&
                      <span className="text-xs text-gray-500 italic ml-1">(Prompt: {scene.imagePrompt.substring(0,30)}...)</span>
                     }
                 </p>
@@ -130,7 +130,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     Edit Scene
                   </button>
                   <button
-                    onClick={() => handleImageUpdate(scene.id)}
+                    onClick={() => handleFootageUpdate(scene.id)}
                     disabled={isGenerating || apiKeyMissing || isUpdatingImage === scene.id}
                     className="px-3 py-1.5 text-xs bg-white hover:bg-gray-200 rounded-md text-black disabled:opacity-50 flex items-center"
                     title={apiKeyMissing && useAiImagesGlobal ? "API Key missing, cannot generate AI image" : (useAiImagesGlobal ? "Refresh AI Image" : "Refresh Placeholder")}

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -59,6 +59,19 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   ]);
   const [activeSlotIndex, setActiveSlotIndex] = useState(0);
 
+  const videoRefs = [useRef<HTMLVideoElement | null>(null), useRef<HTMLVideoElement | null>(null)];
+
+  useEffect(() => {
+    imageSlots.forEach((slot, idx) => {
+      if (slot.scene?.footageType === 'video') {
+        const vid = videoRefs[idx].current;
+        if (vid) {
+          try { vid.currentTime = 0; vid.play().catch(() => {}); } catch {}
+        }
+      }
+    });
+  }, [imageSlots]);
+
   const sceneTimeoutRef = useRef<number | null>(null);
   const progressIntervalRef = useRef<number | null>(null);
   const animationTriggerTimeoutRef = useRef<number | null>(null);
@@ -293,13 +306,24 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (
-            <img
-              key={`slot-${index}-${slot.scene.id}`}
-              src={slot.scene.footageUrl}
-              alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
-              style={getImageStyle(slot)}
-              loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
-            />
+            slot.scene.footageType === 'video' ? (
+              <video
+                key={`slot-${index}-${slot.scene.id}`}
+                ref={videoRefs[index]}
+                src={slot.scene.footageUrl}
+                style={getImageStyle(slot)}
+                muted
+                playsInline
+              />
+            ) : (
+              <img
+                key={`slot-${index}-${slot.scene.id}`}
+                src={slot.scene.footageUrl}
+                alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
+                style={getImageStyle(slot)}
+                loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
+              />
+            )
           ) : null
         ))}
         {currentScene && isPlaying && (

--- a/services/videoRenderingService.ts
+++ b/services/videoRenderingService.ts
@@ -18,9 +18,11 @@ interface VideoRenderOptions {
   includeWatermark: boolean;
 }
 
-interface PreloadedImage {
+interface PreloadedFootage {
   sceneId: string;
-  image: HTMLImageElement;
+  type: 'image' | 'video';
+  image?: HTMLImageElement;
+  video?: HTMLVideoElement;
 }
 
 const FALLBACK_BASE64_IMAGE =
@@ -87,6 +89,33 @@ function drawImageWithKenBurns(
   }
   ctx.drawImage(img, dx, dy, dw, dh);
   ctx.restore();
+}
+
+function drawVideoFrame(
+  ctx: CanvasRenderingContext2D,
+  video: HTMLVideoElement,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  ctx.clearRect(0, 0, canvasWidth, canvasHeight);
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
+  const vidAspect = video.videoWidth / video.videoHeight;
+  const canvasAspect = canvasWidth / canvasHeight;
+  let dx, dy, dw, dh;
+  if (vidAspect > canvasAspect) {
+      dh = canvasHeight;
+      dw = dh * vidAspect;
+      dx = (canvasWidth - dw) / 2;
+      dy = 0;
+  } else {
+      dw = canvasWidth;
+      dh = dw / vidAspect;
+      dx = 0;
+      dy = (canvasHeight - dh) / 2;
+  }
+  ctx.drawImage(video, dx, dy, dw, dh);
 }
 
 
@@ -162,12 +191,38 @@ async function loadImageWithRetries(src: string, sceneId: string, sceneIndexForL
   return fallbackImg;
 }
 
-async function preloadAllImages(
+async function loadVideoWithRetries(src: string, sceneId: string, sceneIndexForLog: number): Promise<HTMLVideoElement> {
+  for (let attempt = 0; attempt <= IMAGE_LOAD_RETRIES; attempt++) {
+    try {
+      const video = await new Promise<HTMLVideoElement>((resolve, reject) => {
+        const vid = document.createElement('video');
+        if (!src.startsWith('data:')) {
+            vid.crossOrigin = 'anonymous';
+        }
+        vid.onloadeddata = () => resolve(vid);
+        vid.onerror = () => reject(new Error('failed to load video'));
+        vid.src = src;
+      });
+      return video;
+    } catch (error) {
+      console.warn(`Video load attempt ${attempt + 1} failed for scene ${sceneIndexForLog + 1}. Error: ${(error as Error).message}`);
+      if (attempt < IMAGE_LOAD_RETRIES) {
+        const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        await new Promise(res => setTimeout(res, delay));
+      }
+    }
+  }
+  const vid = document.createElement('video');
+  vid.src = '';
+  return vid;
+}
+
+async function preloadAllFootage(
     scenes: Scene[],
     onProgress: (message: string, value: number) => void
-): Promise<PreloadedImage[]> {
-    onProgress("Preloading images...", 0);
-    const results: PreloadedImage[] = [];
+): Promise<PreloadedFootage[]> {
+    onProgress("Preloading footage...", 0);
+    const results: PreloadedFootage[] = [];
     const concurrency = 3;
     let index = 0;
     let completed = 0;
@@ -176,15 +231,20 @@ async function preloadAllImages(
         while (index < scenes.length) {
             const i = index++;
             const scene = scenes[i];
-            const img = await loadImageWithRetries(scene.footageUrl, scene.id, i);
-            results.push({ sceneId: scene.id, image: img });
+            if (scene.footageType === 'video') {
+                const vid = await loadVideoWithRetries(scene.footageUrl, scene.id, i);
+                results.push({ sceneId: scene.id, type: 'video', video: vid });
+            } else {
+                const img = await loadImageWithRetries(scene.footageUrl, scene.id, i);
+                results.push({ sceneId: scene.id, type: 'image', image: img });
+            }
             completed++;
-            onProgress(`Preloading images... (${completed}/${scenes.length})`, completed / scenes.length);
+            onProgress(`Preloading footage... (${completed}/${scenes.length})`, completed / scenes.length);
         }
     }
 
     await Promise.all(Array(Math.min(concurrency, scenes.length)).fill(0).map(worker));
-    onProgress("All images preloaded.", 1);
+    onProgress("All footage preloaded.", 1);
     return results;
 }
 
@@ -219,7 +279,7 @@ export const generateWebMFromScenes = (
 
     const recordedChunks: BlobPart[] = [];
     let mediaRecorder: MediaRecorder | null = null;
-    let preloadedImages: PreloadedImage[] = [];
+    let preloadedFootage: PreloadedFootage[] = [];
     let animationFrameId: number | null = null;
 
     const updateOverallProgress = (stageProgress: number, stageWeight: number, baseProgress: number) => {
@@ -229,8 +289,8 @@ export const generateWebMFromScenes = (
     };
 
     try {
-        // Stage 1: Preload images (0% - 20% of progress)
-        preloadedImages = await preloadAllImages(scenes, (_msg, val) => {
+        // Stage 1: Preload footage (0% - 20% of progress)
+        preloadedFootage = await preloadAllFootage(scenes, (_msg, val) => {
             // console.log(`[Preload Progress] ${_msg} - ${val}`); // Optional detailed logging
             updateOverallProgress(val, 0.2, 0);
         });
@@ -327,21 +387,28 @@ export const generateWebMFromScenes = (
             }
 
             const scene = scenes[currentSceneIndex];
-            const preloadedImgData = preloadedImages.find(pi => pi.sceneId === scene.id);
-            
-            if (!preloadedImgData) {
-                console.error(`[Video Rendering Service] Preloaded image not found for scene ID: ${scene.id}`);
+            const preloadedData = preloadedFootage.find(pi => pi.sceneId === scene.id);
+
+            if (!preloadedData) {
+                console.error(`[Video Rendering Service] Preloaded footage not found for scene ID: ${scene.id}`);
                 if (mediaRecorder && mediaRecorder.state === "recording") mediaRecorder.stop(); else if (stream.getTracks) stream.getTracks().forEach(track => track.stop());
-                reject(new Error(`Internal error: Preloaded image missing for scene ${scene.id}`));
+                reject(new Error(`Internal error: Preloaded footage missing for scene ${scene.id}`));
                 return;
             }
-            
-            const img = preloadedImgData.image;
+
             const numFramesForThisScene = Math.round(scene.duration * VIDEO_FPS);
             const progressInThisScene = numFramesForThisScene <= 1 ? 1 : currentFrameInScene / (numFramesForThisScene -1);
 
             try {
-                drawImageWithKenBurns(ctx, img, canvasWidth, canvasHeight, progressInThisScene, scene.kenBurnsConfig);
+                if (preloadedData.type === 'video' && preloadedData.video) {
+                    const videoEl = preloadedData.video;
+                    if (videoEl.duration) {
+                        videoEl.currentTime = Math.min(videoEl.duration, progressInThisScene * videoEl.duration);
+                    }
+                    drawVideoFrame(ctx, videoEl, canvasWidth, canvasHeight);
+                } else if (preloadedData.image) {
+                    drawImageWithKenBurns(ctx, preloadedData.image, canvasWidth, canvasHeight, progressInThisScene, scene.kenBurnsConfig);
+                }
                 if (options.includeWatermark) {
                     drawWatermark(ctx, canvasWidth, canvasHeight, WATERMARK_TEXT);
                 }

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -23,8 +23,8 @@ const generateSceneKenBurnsConfig = (duration: number): KenBurnsConfig => {
 };
 
 
-// Fetches a placeholder image URL based on keywords.
-export const fetchPlaceholderFootageUrl = async (
+// Fetches a placeholder video URL based on keywords.
+export const fetchPlaceholderVideoUrl = async (
   keywords: string[],
   aspectRatio: AspectRatio,
   sceneId?: string // Optional sceneId for more unique placeholders if needed
@@ -41,15 +41,17 @@ export const fetchPlaceholderFootageUrl = async (
   if (PEXELS_API_KEY) {
     try {
       const resp = await fetch(
-        `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
+        `https://api.pexels.com/videos/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
         { headers: { Authorization: PEXELS_API_KEY } }
       );
       if (resp.ok) {
         const data = await resp.json();
-        if (data.photos && data.photos.length > 0) {
-          const photo = data.photos[Math.floor(Math.random() * data.photos.length)];
-          const url = photo.src.large2x || photo.src.large || photo.src.original;
-          return `${url}?random_bust=${Date.now()}`;
+        if (data.videos && data.videos.length > 0) {
+          const video = data.videos[Math.floor(Math.random() * data.videos.length)];
+          const mp4 = video.video_files.find((f: any) => f.file_type === 'video/mp4' && f.width <= 1280) || video.video_files[0];
+          if (mp4 && mp4.link) {
+            return `${mp4.link}?random_bust=${Date.now()}`;
+          }
         }
       } else {
         console.warn(`Pexels API request failed with ${resp.status}`);
@@ -58,11 +60,10 @@ export const fetchPlaceholderFootageUrl = async (
       console.warn('Error fetching from Pexels API:', err);
     }
   } else {
-    console.warn('PEXELS_API_KEY not set. Falling back to loremflickr.');
+    console.warn('PEXELS_API_KEY not set. Falling back to sample video.');
   }
 
-  const encodedQuery = encodeURIComponent(query);
-  return `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`;
+  return `https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4?cache_bust=${sceneId || Date.now()}`;
 };
 
 export interface ProcessNarrationOptions {
@@ -104,6 +105,7 @@ export const processNarrationToScenes = async (
     const item = scenesToProcess[index];
     const sceneId = options.generateSpecificImageForSceneId || `scene-${index}-${Date.now()}`;
     let footageUrl = '';
+    let footageType: 'image' | 'video' = 'video';
     let imageGenError: string | undefined = undefined;
 
     const duration = item.duration > 0 ? item.duration : calculateDurationFromText(item.sceneText);
@@ -120,11 +122,13 @@ export const processNarrationToScenes = async (
       const imagenResult = await generateImageWithImagen(item.imagePrompt, sceneId);
       if (imagenResult.base64Image) {
         footageUrl = imagenResult.base64Image;
+        footageType = 'image';
       } else {
         imageGenError = imagenResult.userFriendlyError || 'AI image generation failed. Using placeholder.';
         console.warn(imageGenError, "Prompt:", item.imagePrompt);
         onProgress(imageGenError, (index + 1) / scenesToProcess.length, 'ai_image', index + 1, scenesToProcess.length, imageGenError);
-        footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+        footageUrl = await fetchPlaceholderVideoUrl(item.keywords, aspectRatio, sceneId);
+        footageType = 'video';
       }
     } else {
       onProgress(
@@ -134,7 +138,8 @@ export const processNarrationToScenes = async (
         index + 1,
         scenesToProcess.length
       );
-      footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+      footageUrl = await fetchPlaceholderVideoUrl(item.keywords, aspectRatio, sceneId);
+      footageType = 'video';
     }
     
     const kenBurnsConfig = generateSceneKenBurnsConfig(validatedDuration);
@@ -143,6 +148,7 @@ export const processNarrationToScenes = async (
         const sceneToUpdateIndex = existingScenes.findIndex(s => s.id === options.generateSpecificImageForSceneId);
         if (sceneToUpdateIndex !== -1) {
             existingScenes[sceneToUpdateIndex].footageUrl = footageUrl;
+            existingScenes[sceneToUpdateIndex].footageType = footageType;
             existingScenes[sceneToUpdateIndex].kenBurnsConfig = kenBurnsConfig; // Re-gen KB if image changes
             // Optionally update keywords/imagePrompt if they were also re-analyzed
             existingScenes[sceneToUpdateIndex].imagePrompt = item.imagePrompt; 
@@ -164,6 +170,7 @@ export const processNarrationToScenes = async (
           imagePrompt: item.imagePrompt,
           duration: validatedDuration,
           footageUrl: footageUrl,
+          footageType: footageType,
           kenBurnsConfig: kenBurnsConfig,
         });
     }

--- a/types.ts
+++ b/types.ts
@@ -14,7 +14,8 @@ export interface Scene {
   keywords: string[];
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
-  footageUrl: string; // URL to image (can be base64 data URL)
+  footageUrl: string; // URL to image or video
+  footageType: 'image' | 'video';
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- support `footageType` for scenes
- fetch placeholder videos from Pexels API
- preview video clips in the editor
- preload video assets for rendering
- adjust rendering service to draw video frames

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685435dc31b4832e966461594844e3cd