### PR TITLE
Switch to Pexels video placeholders

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import SceneEditor from './components/SceneEditor.tsx'; // New Component
 import { Scene, AspectRatio, GeminiSceneResponseItem } from './types.ts';
 import { APP_TITLE, DEFAULT_ASPECT_RATIO, API_KEY, IS_PREMIUM_USER } from './constants.ts';
 import { analyzeNarrationWithGemini, generateImageWithImagen } from './services/geminiService.ts';
-import { processNarrationToScenes, fetchPlaceholderFootageUrl } from './services/videoService.ts';
+import { processNarrationToScenes, fetchPlaceholderVideoUrl, fetchPlaceholderImageUrl } from './services/videoService.ts';
 import { generateWebMFromScenes } from './services/videoRenderingService.ts';
 import { convertWebMToMP4 } from './services/mp4ConversionService.ts';
 import { generateAIVideo } from './services/aiVideoGenerationService.ts';
@@ -312,7 +312,8 @@ const App: React.FC = () => {
 
   const handleAddScene = async () => {
     const newSceneId = `scene-new-${Date.now()}`;
-    const placeholder = await fetchPlaceholderFootageUrl(["new scene", "abstract"], aspectRatio, newSceneId);
+    const placeholderVideo = await fetchPlaceholderVideoUrl(["new scene", "abstract"], aspectRatio);
+    const placeholder = placeholderVideo || await fetchPlaceholderImageUrl(["new scene", "abstract"], aspectRatio, newSceneId);
     const newScene: Scene = {
       id: newSceneId,
       sceneText: "New scene text...",
@@ -320,6 +321,7 @@ const App: React.FC = () => {
       imagePrompt: "Abstract background for a new scene",
       duration: 5,
       footageUrl: placeholder,
+      mediaType: placeholderVideo ? 'video' : 'image',
       kenBurnsConfig: { targetScale: 1.1, targetXPercent: 0, targetYPercent: 0, originXRatio: 0.5, originYRatio: 0.5, animationDurationS: 5 }
     };
     setScenes(prevScenes => [...prevScenes, newScene]);
@@ -345,16 +347,30 @@ const App: React.FC = () => {
                 newFootageUrl = result.base64Image;
             } else {
                 addWarning(result.userFriendlyError || `AI image failed for scene ${sceneId}. Using new placeholder.`);
-                newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
+                  const vid = await fetchPlaceholderVideoUrl(sceneToUpdate.keywords, aspectRatio);
+                if (vid) {
+                    newFootageUrl = vid;
+                    sceneToUpdate.mediaType = 'video';
+                } else {
+                    newFootageUrl = await fetchPlaceholderImageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
+                    sceneToUpdate.mediaType = 'image';
+                }
                 errorOccurred = true;
             }
         } else {
             setProgressValue(30);
-            newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
+            const vid = await fetchPlaceholderVideoUrl(sceneToUpdate.keywords, aspectRatio);
+            if (vid) {
+                newFootageUrl = vid;
+                sceneToUpdate.mediaType = 'video';
+            } else {
+                newFootageUrl = await fetchPlaceholderImageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
+                sceneToUpdate.mediaType = 'image';
+            }
         }
-        
+
         setScenes(prevScenes => prevScenes.map(s =>
-            s.id === sceneId ? { ...s, footageUrl: newFootageUrl } : s
+            s.id === sceneId ? { ...s, footageUrl: newFootageUrl, mediaType: sceneToUpdate.mediaType } : s
         ));
         setProgressMessage(errorOccurred ? 'Image updated with placeholder.' : 'Image updated successfully!');
         setProgressValue(100);

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -112,12 +112,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 </p>
                 <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
                 <p className="text-gray-300 text-sm truncate">
-                    <strong className="text-gray-400">Image:</strong> {
-                        scene.footageUrl.startsWith('data:image') ? 
-                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 
-                        'Placeholder'
+                    <strong className="text-gray-400">Footage:</strong> {
+                        scene.mediaType === 'image'
+                          ? (scene.footageUrl.startsWith('data:image') ? (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 'Placeholder')
+                          : 'Video'
                     }
-                    {scene.footageUrl.startsWith('data:image') && scene.imagePrompt && 
+                    {scene.mediaType === 'image' && scene.footageUrl.startsWith('data:image') && scene.imagePrompt &&
                      <span className="text-xs text-gray-500 italic ml-1">(Prompt: {scene.imagePrompt.substring(0,30)}...)</span>
                     }
                 </p>

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -5,7 +5,7 @@ import { PlayIcon, PauseIcon, DownloadIcon } from './IconComponents.tsx';
 
 const FADE_DURATION_MS = 1000; // 1 second for cross-fade
 
-interface ImageSlotState {
+interface MediaSlotState {
   scene: Scene | null;
   opacity: number;
   zIndex: number;
@@ -28,7 +28,7 @@ interface VideoPreviewProps {
   ttsPlaybackStatus: 'idle' | 'playing' | 'paused' | 'ended';
 }
 
-const getDefaultSlotState = (): ImageSlotState => ({
+const getDefaultSlotState = (): MediaSlotState => ({
   scene: null,
   opacity: 0,
   zIndex: 0,
@@ -54,7 +54,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const [isPlaying, setIsPlaying] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0);
 
-  const [imageSlots, setImageSlots] = useState<[ImageSlotState, ImageSlotState]>([
+  const [imageSlots, setImageSlots] = useState<[MediaSlotState, MediaSlotState]>([
     getDefaultSlotState(), getDefaultSlotState()
   ]);
   const [activeSlotIndex, setActiveSlotIndex] = useState(0);
@@ -62,6 +62,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const sceneTimeoutRef = useRef<number | null>(null);
   const progressIntervalRef = useRef<number | null>(null);
   const animationTriggerTimeoutRef = useRef<number | null>(null);
+  const videoRefs = useRef<(HTMLVideoElement | null)[]>([null, null]);
 
   const currentScene = scenes[currentSceneIndex];
 
@@ -116,7 +117,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
     const cssTransformOrigin = `${kbConfig.originXRatio * 100}% ${kbConfig.originYRatio * 100}%`;
 
     setImageSlots(prevSlots => {
-      const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+      const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
       newSlots[primarySlot] = {
         scene: currentScene,
         opacity: 1,
@@ -132,10 +133,14 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       }
       return newSlots;
     });
+    if (currentScene.mediaType === 'video') {
+      const vid = videoRefs.current[primarySlot];
+      if (vid) { vid.currentTime = 0; vid.play().catch(() => {}); }
+    }
 
     animationTriggerTimeoutRef.current = window.setTimeout(() => {
       setImageSlots(prevSlots => {
-        const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+        const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
         if (newSlots[primarySlot].scene?.id === currentScene.id) {
           newSlots[primarySlot].transform = targetCSSTransform;
           newSlots[primarySlot].transition = `opacity ${FADE_DURATION_MS}ms ease-in-out, transform ${kbConfig.animationDurationS}s linear`;
@@ -168,7 +173,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
 
         setImageSlots(prevSlots => {
-          const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+          const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
           newSlots[primarySlot] = { ...newSlots[primarySlot], opacity: 0, zIndex: 5 };
           newSlots[secondarySlot] = {
             scene: nextScene,
@@ -180,10 +185,14 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           };
           return newSlots;
         });
+        if (nextScene.mediaType === 'video') {
+          const vid = videoRefs.current[secondarySlot];
+          if (vid) { vid.currentTime = 0; vid.play().catch(() => {}); }
+        }
 
         animationTriggerTimeoutRef.current = window.setTimeout(() => {
           setImageSlots(prevSlots => {
-            const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+            const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
             if (newSlots[secondarySlot].scene?.id === nextScene.id) {
               newSlots[secondarySlot].transform = nextTargetCSSTransform;
               newSlots[secondarySlot].transition = `opacity ${FADE_DURATION_MS}ms ease-in-out, transform ${nextKbConfig.animationDurationS}s linear`;
@@ -199,7 +208,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
       } else { 
         setImageSlots(prevSlots => {
-          const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+          const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
           newSlots[primarySlot] = { ...newSlots[primarySlot], opacity: 0 };
           return newSlots;
         });
@@ -233,28 +242,32 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
     if (newIsPlaying) {
         if (currentSceneIndex === scenes.length - 1 && elapsedTime >= (currentScene?.duration || 0) * 1000) {
-            handleRestart(); 
+            handleRestart();
         } else {
            if (ttsPlaybackStatus === 'paused') onTTSResume();
         }
+        const vid = videoRefs.current[activeSlotIndex];
+        if (vid) vid.play().catch(() => {});
     } else {
         if (ttsPlaybackStatus === 'playing') onTTSPause();
+        videoRefs.current.forEach(v => v?.pause());
     }
   };
 
   const handleRestart = () => {
     if (scenes.length === 0 || isGenerating) return;
-    onTTSStop(); 
+    onTTSStop();
     setCurrentSceneIndex(0);
     setActiveSlotIndex(0);
     setImageSlots([getDefaultSlotState(), getDefaultSlotState()]);
+    videoRefs.current.forEach(v => { if (v) { v.currentTime = 0; v.pause(); } });
     setElapsedTime(0);
-    setIsPlaying(true); 
+    setIsPlaying(true);
   };
 
   const footageAspectRatioClass = aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]';
 
-  const getImageStyle = (slotState: ImageSlotState): React.CSSProperties => ({
+  const getMediaStyle = (slotState: MediaSlotState): React.CSSProperties => ({
     position: 'absolute',
     inset: 0,
     width: '100%',
@@ -293,13 +306,25 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (
-            <img
-              key={`slot-${index}-${slot.scene.id}`}
-              src={slot.scene.footageUrl}
-              alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
-              style={getImageStyle(slot)}
-              loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
-            />
+            slot.scene.mediaType === 'video' ? (
+              <video
+                key={`slot-${index}-${slot.scene.id}`}
+                ref={el => (videoRefs.current[index] = el)}
+                src={slot.scene.footageUrl}
+                style={getMediaStyle(slot)}
+                muted
+                playsInline
+                loop
+              />
+            ) : (
+              <img
+                key={`slot-${index}-${slot.scene.id}`}
+                src={slot.scene.footageUrl}
+                alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
+                style={getMediaStyle(slot)}
+                loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
+              />
+            )
           ) : null
         ))}
         {currentScene && isPlaying && (

--- a/services/videoRenderingService.ts
+++ b/services/videoRenderingService.ts
@@ -90,27 +90,6 @@ function drawImageWithKenBurns(
 }
 
 
-function wrapText(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, maxWidth: number, lineHeight: number) {
-  const words = text.split(' ');
-  let line = '';
-  const lines = [];
-
-  for (let n = 0; n < words.length; n++) {
-    const testLine = line + words[n] + ' ';
-    const metrics = ctx.measureText(testLine);
-    if (metrics.width > maxWidth && n > 0) {
-      lines.push(line.trim());
-      line = words[n] + ' ';
-    } else {
-      line = testLine;
-    }
-  }
-  lines.push(line.trim());
-
-  lines.forEach((singleLine, index) => {
-    ctx.fillText(singleLine, x, y + (index * lineHeight));
-  });
-}
 
 
 function drawWatermark(ctx: CanvasRenderingContext2D, canvasWidth: number, canvasHeight: number, text: string) {

--- a/types.ts
+++ b/types.ts
@@ -15,6 +15,7 @@ export interface Scene {
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
   footageUrl: string; // URL to image (can be base64 data URL)
+  mediaType: 'image' | 'video';
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- add `mediaType` to `Scene`
- fetch placeholder videos from Pexels
- update scene processing to prefer videos
- support video playback in the preview
- adjust editor display for image vs video

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68543c303864832ebcff91aa340fb9ba