### PR TITLE
Support video placeholders from Pexels

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -319,7 +319,8 @@ const App: React.FC = () => {
       keywords: ["new scene"],
       imagePrompt: "Abstract background for a new scene",
       duration: 5,
-      footageUrl: placeholder,
+      footageUrl: placeholder.url,
+      footageType: placeholder.type,
       kenBurnsConfig: { targetScale: 1.1, targetXPercent: 0, targetYPercent: 0, originXRatio: 0.5, originYRatio: 0.5, animationDurationS: 5 }
     };
     setScenes(prevScenes => [...prevScenes, newScene]);
@@ -335,6 +336,7 @@ const App: React.FC = () => {
     setProgressValue(0); // Simple progress for single image update
     
     let newFootageUrl = '';
+    let newFootageType: 'image' | 'video' = 'image';
     let errorOccurred = false;
 
     try {
@@ -343,18 +345,23 @@ const App: React.FC = () => {
             const result = await generateImageWithImagen(sceneToUpdate.imagePrompt, sceneId);
             if (result.base64Image) {
                 newFootageUrl = result.base64Image;
+                newFootageType = 'image';
             } else {
                 addWarning(result.userFriendlyError || `AI image failed for scene ${sceneId}. Using new placeholder.`);
-                newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
+                const ph = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-retry");
+                newFootageUrl = ph.url;
+                newFootageType = ph.type;
                 errorOccurred = true;
             }
         } else {
             setProgressValue(30);
-            newFootageUrl = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
+            const ph = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneId + "-refresh");
+            newFootageUrl = ph.url;
+            newFootageType = ph.type;
         }
         
         setScenes(prevScenes => prevScenes.map(s =>
-            s.id === sceneId ? { ...s, footageUrl: newFootageUrl } : s
+            s.id === sceneId ? { ...s, footageUrl: newFootageUrl, footageType: newFootageType } : s
         ));
         setProgressMessage(errorOccurred ? 'Image updated with placeholder.' : 'Image updated successfully!');
         setProgressValue(100);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **AI-Powered Video Narration Tool**
 
-CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder footage, subtitles and final video rendering right in your browser.
+CineSynth transforms text scripts into marketing-ready videos in minutes. Powered by Gemini and Imagen models, it handles scene analysis, placeholder video footage from Pexels, subtitles and final video rendering right in your browser.
 
 ## Features
 
@@ -18,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` to enable placeholder videos from Pexels. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -112,12 +112,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 </p>
                 <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
                 <p className="text-gray-300 text-sm truncate">
-                    <strong className="text-gray-400">Image:</strong> {
-                        scene.footageUrl.startsWith('data:image') ? 
-                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 
-                        'Placeholder'
+                    <strong className="text-gray-400">Footage:</strong> {
+                        scene.footageType === 'image'
+                            ? (scene.footageUrl.startsWith('data:image') ? (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 'Placeholder Image')
+                            : 'Video Placeholder'
                     }
-                    {scene.footageUrl.startsWith('data:image') && scene.imagePrompt && 
+                    {scene.footageType === 'image' && scene.footageUrl.startsWith('data:image') && scene.imagePrompt &&
                      <span className="text-xs text-gray-500 italic ml-1">(Prompt: {scene.imagePrompt.substring(0,30)}...)</span>
                     }
                 </p>

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -5,7 +5,7 @@ import { PlayIcon, PauseIcon, DownloadIcon } from './IconComponents.tsx';
 
 const FADE_DURATION_MS = 1000; // 1 second for cross-fade
 
-interface ImageSlotState {
+interface MediaSlotState {
   scene: Scene | null;
   opacity: number;
   zIndex: number;
@@ -28,7 +28,7 @@ interface VideoPreviewProps {
   ttsPlaybackStatus: 'idle' | 'playing' | 'paused' | 'ended';
 }
 
-const getDefaultSlotState = (): ImageSlotState => ({
+const getDefaultSlotState = (): MediaSlotState => ({
   scene: null,
   opacity: 0,
   zIndex: 0,
@@ -54,10 +54,12 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   const [isPlaying, setIsPlaying] = useState(false);
   const [elapsedTime, setElapsedTime] = useState(0);
 
-  const [imageSlots, setImageSlots] = useState<[ImageSlotState, ImageSlotState]>([
+  const [imageSlots, setImageSlots] = useState<[MediaSlotState, MediaSlotState]>([
     getDefaultSlotState(), getDefaultSlotState()
   ]);
   const [activeSlotIndex, setActiveSlotIndex] = useState(0);
+
+  const videoRefs = [useRef<HTMLVideoElement | null>(null), useRef<HTMLVideoElement | null>(null)];
 
   const sceneTimeoutRef = useRef<number | null>(null);
   const progressIntervalRef = useRef<number | null>(null);
@@ -116,7 +118,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
     const cssTransformOrigin = `${kbConfig.originXRatio * 100}% ${kbConfig.originYRatio * 100}%`;
 
     setImageSlots(prevSlots => {
-      const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+      const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
       newSlots[primarySlot] = {
         scene: currentScene,
         opacity: 1,
@@ -127,15 +129,27 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       };
       if (newSlots[secondarySlot].opacity !== 0) {
         newSlots[secondarySlot] = { ...newSlots[secondarySlot], opacity: 0, zIndex: 5 };
+        if (newSlots[secondarySlot].scene?.footageType === 'video') {
+          const vid = videoRefs[secondarySlot].current;
+          vid?.pause();
+        }
       } else {
         newSlots[secondarySlot].zIndex = 5;
       }
       return newSlots;
     });
 
+    if (currentScene.footageType === 'video') {
+      const vid = videoRefs[primarySlot].current;
+      if (vid) {
+        vid.currentTime = 0;
+        if (isPlaying) vid.play().catch(() => {});
+      }
+    }
+
     animationTriggerTimeoutRef.current = window.setTimeout(() => {
       setImageSlots(prevSlots => {
-        const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+        const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
         if (newSlots[primarySlot].scene?.id === currentScene.id) {
           newSlots[primarySlot].transform = targetCSSTransform;
           newSlots[primarySlot].transition = `opacity ${FADE_DURATION_MS}ms ease-in-out, transform ${kbConfig.animationDurationS}s linear`;
@@ -168,8 +182,12 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
 
         setImageSlots(prevSlots => {
-          const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+          const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
           newSlots[primarySlot] = { ...newSlots[primarySlot], opacity: 0, zIndex: 5 };
+          if (newSlots[primarySlot].scene?.footageType === 'video') {
+            const vid = videoRefs[primarySlot].current;
+            vid?.pause();
+          }
           newSlots[secondarySlot] = {
             scene: nextScene,
             opacity: 1,
@@ -181,9 +199,17 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           return newSlots;
         });
 
+        if (nextScene.footageType === 'video') {
+          const vid = videoRefs[secondarySlot].current;
+          if (vid) {
+            vid.currentTime = 0;
+            if (isPlaying) vid.play().catch(() => {});
+          }
+        }
+
         animationTriggerTimeoutRef.current = window.setTimeout(() => {
           setImageSlots(prevSlots => {
-            const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+            const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
             if (newSlots[secondarySlot].scene?.id === nextScene.id) {
               newSlots[secondarySlot].transform = nextTargetCSSTransform;
               newSlots[secondarySlot].transition = `opacity ${FADE_DURATION_MS}ms ease-in-out, transform ${nextKbConfig.animationDurationS}s linear`;
@@ -199,7 +225,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
       } else { 
         setImageSlots(prevSlots => {
-          const newSlots = [...prevSlots] as [ImageSlotState, ImageSlotState];
+          const newSlots = [...prevSlots] as [MediaSlotState, MediaSlotState];
           newSlots[primarySlot] = { ...newSlots[primarySlot], opacity: 0 };
           return newSlots;
         });
@@ -254,7 +280,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
 
   const footageAspectRatioClass = aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]';
 
-  const getImageStyle = (slotState: ImageSlotState): React.CSSProperties => ({
+  const getMediaStyle = (slotState: MediaSlotState): React.CSSProperties => ({
     position: 'absolute',
     inset: 0,
     width: '100%',
@@ -293,13 +319,24 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (
-            <img
-              key={`slot-${index}-${slot.scene.id}`}
-              src={slot.scene.footageUrl}
-              alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
-              style={getImageStyle(slot)}
-              loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
-            />
+            slot.scene.footageType === 'video' ? (
+              <video
+                key={`slot-${index}-${slot.scene.id}`}
+                ref={videoRefs[index]}
+                src={slot.scene.footageUrl}
+                style={getMediaStyle(slot)}
+                playsInline
+                muted
+              />
+            ) : (
+              <img
+                key={`slot-${index}-${slot.scene.id}`}
+                src={slot.scene.footageUrl}
+                alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
+                style={getMediaStyle(slot)}
+                loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
+              />
+            )
           ) : null
         ))}
         {currentScene && isPlaying && (

--- a/services/videoRenderingService.ts
+++ b/services/videoRenderingService.ts
@@ -18,9 +18,12 @@ interface VideoRenderOptions {
   includeWatermark: boolean;
 }
 
-interface PreloadedImage {
+interface PreloadedMedia {
   sceneId: string;
-  image: HTMLImageElement;
+  type: 'image' | 'video';
+  image?: HTMLImageElement;
+  video?: HTMLVideoElement;
+  duration: number;
 }
 
 const FALLBACK_BASE64_IMAGE =
@@ -162,12 +165,41 @@ async function loadImageWithRetries(src: string, sceneId: string, sceneIndexForL
   return fallbackImg;
 }
 
-async function preloadAllImages(
+async function loadVideoWithRetries(src: string, sceneId: string, sceneIndexForLog: number): Promise<HTMLVideoElement> {
+  for (let attempt = 0; attempt <= IMAGE_LOAD_RETRIES; attempt++) {
+    try {
+      const video = document.createElement('video');
+      if (!src.startsWith('data:')) {
+        video.crossOrigin = 'anonymous';
+      }
+      video.preload = 'auto';
+      video.src = src;
+      await new Promise<void>((resolve, reject) => {
+        video.onloadeddata = () => resolve();
+        video.onerror = (e) => {
+          reject(new Error(`Failed to load video for scene ${sceneIndexForLog + 1} (ID: ${sceneId}).`));
+        };
+      });
+      return video;
+    } catch (error) {
+      console.warn(`Video load attempt ${attempt + 1} failed for scene ${sceneIndexForLog + 1}.`, error);
+      if (attempt < IMAGE_LOAD_RETRIES) {
+        const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        await new Promise(res => setTimeout(res, delay));
+      } else {
+        throw error;
+      }
+    }
+  }
+  throw new Error('Failed to load video');
+}
+
+async function preloadAllMedia(
     scenes: Scene[],
     onProgress: (message: string, value: number) => void
-): Promise<PreloadedImage[]> {
-    onProgress("Preloading images...", 0);
-    const results: PreloadedImage[] = [];
+): Promise<PreloadedMedia[]> {
+    onProgress("Preloading media...", 0);
+    const results: PreloadedMedia[] = [];
     const concurrency = 3;
     let index = 0;
     let completed = 0;
@@ -176,15 +208,20 @@ async function preloadAllImages(
         while (index < scenes.length) {
             const i = index++;
             const scene = scenes[i];
-            const img = await loadImageWithRetries(scene.footageUrl, scene.id, i);
-            results.push({ sceneId: scene.id, image: img });
+            if (scene.footageType === 'video') {
+                const vid = await loadVideoWithRetries(scene.footageUrl, scene.id, i);
+                results.push({ sceneId: scene.id, type: 'video', video: vid, duration: vid.duration || scene.duration });
+            } else {
+                const img = await loadImageWithRetries(scene.footageUrl, scene.id, i);
+                results.push({ sceneId: scene.id, type: 'image', image: img, duration: scene.duration });
+            }
             completed++;
-            onProgress(`Preloading images... (${completed}/${scenes.length})`, completed / scenes.length);
+            onProgress(`Preloading media... (${completed}/${scenes.length})`, completed / scenes.length);
         }
     }
 
     await Promise.all(Array(Math.min(concurrency, scenes.length)).fill(0).map(worker));
-    onProgress("All images preloaded.", 1);
+    onProgress("All media preloaded.", 1);
     return results;
 }
 
@@ -219,7 +256,7 @@ export const generateWebMFromScenes = (
 
     const recordedChunks: BlobPart[] = [];
     let mediaRecorder: MediaRecorder | null = null;
-    let preloadedImages: PreloadedImage[] = [];
+    let preloadedMediaList: PreloadedMedia[] = [];
     let animationFrameId: number | null = null;
 
     const updateOverallProgress = (stageProgress: number, stageWeight: number, baseProgress: number) => {
@@ -229,8 +266,8 @@ export const generateWebMFromScenes = (
     };
 
     try {
-        // Stage 1: Preload images (0% - 20% of progress)
-        preloadedImages = await preloadAllImages(scenes, (_msg, val) => {
+        // Stage 1: Preload media (0% - 20% of progress)
+        preloadedMediaList = await preloadAllMedia(scenes, (_msg, val) => {
             // console.log(`[Preload Progress] ${_msg} - ${val}`); // Optional detailed logging
             updateOverallProgress(val, 0.2, 0);
         });
@@ -327,21 +364,26 @@ export const generateWebMFromScenes = (
             }
 
             const scene = scenes[currentSceneIndex];
-            const preloadedImgData = preloadedImages.find(pi => pi.sceneId === scene.id);
-            
-            if (!preloadedImgData) {
-                console.error(`[Video Rendering Service] Preloaded image not found for scene ID: ${scene.id}`);
+            const preloaded = preloadedMediaList.find(pi => pi.sceneId === scene.id);
+
+            if (!preloaded) {
+                console.error(`[Video Rendering Service] Preloaded media not found for scene ID: ${scene.id}`);
                 if (mediaRecorder && mediaRecorder.state === "recording") mediaRecorder.stop(); else if (stream.getTracks) stream.getTracks().forEach(track => track.stop());
-                reject(new Error(`Internal error: Preloaded image missing for scene ${scene.id}`));
+                reject(new Error(`Internal error: Preloaded media missing for scene ${scene.id}`));
                 return;
             }
-            
-            const img = preloadedImgData.image;
+
             const numFramesForThisScene = Math.round(scene.duration * VIDEO_FPS);
             const progressInThisScene = numFramesForThisScene <= 1 ? 1 : currentFrameInScene / (numFramesForThisScene -1);
 
             try {
-                drawImageWithKenBurns(ctx, img, canvasWidth, canvasHeight, progressInThisScene, scene.kenBurnsConfig);
+                if (preloaded.type === 'video' && preloaded.video) {
+                    const vid = preloaded.video;
+                    vid.currentTime = Math.min(preloaded.duration, progressInThisScene * preloaded.duration);
+                    ctx.drawImage(vid, 0, 0, canvasWidth, canvasHeight);
+                } else if (preloaded.image) {
+                    drawImageWithKenBurns(ctx, preloaded.image, canvasWidth, canvasHeight, progressInThisScene, scene.kenBurnsConfig);
+                }
                 if (options.includeWatermark) {
                     drawWatermark(ctx, canvasWidth, canvasHeight, WATERMARK_TEXT);
                 }

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -24,11 +24,16 @@ const generateSceneKenBurnsConfig = (duration: number): KenBurnsConfig => {
 
 
 // Fetches a placeholder image URL based on keywords.
+export interface PlaceholderFootageResult {
+  url: string;
+  type: 'video' | 'image';
+}
+
 export const fetchPlaceholderFootageUrl = async (
   keywords: string[],
   aspectRatio: AspectRatio,
   sceneId?: string // Optional sceneId for more unique placeholders if needed
-): Promise<string> => {
+): Promise<PlaceholderFootageResult> => {
   const width = aspectRatio === '16:9' ? 960 : 540; // smaller for faster downloads
   const height = aspectRatio === '16:9' ? 540 : 960;
 
@@ -41,15 +46,17 @@ export const fetchPlaceholderFootageUrl = async (
   if (PEXELS_API_KEY) {
     try {
       const resp = await fetch(
-        `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
+        `https://api.pexels.com/videos/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
         { headers: { Authorization: PEXELS_API_KEY } }
       );
       if (resp.ok) {
         const data = await resp.json();
-        if (data.photos && data.photos.length > 0) {
-          const photo = data.photos[Math.floor(Math.random() * data.photos.length)];
-          const url = photo.src.large2x || photo.src.large || photo.src.original;
-          return `${url}?random_bust=${Date.now()}`;
+        if (data.videos && data.videos.length > 0) {
+          const video = data.videos[Math.floor(Math.random() * data.videos.length)];
+          const mp4 = video.video_files.find((f: any) => f.file_type === 'video/mp4');
+          if (mp4 && mp4.link) {
+            return { url: mp4.link, type: 'video' };
+          }
         }
       } else {
         console.warn(`Pexels API request failed with ${resp.status}`);
@@ -62,7 +69,7 @@ export const fetchPlaceholderFootageUrl = async (
   }
 
   const encodedQuery = encodeURIComponent(query);
-  return `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`;
+  return { url: `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`, type: 'image' };
 };
 
 export interface ProcessNarrationOptions {
@@ -104,6 +111,7 @@ export const processNarrationToScenes = async (
     const item = scenesToProcess[index];
     const sceneId = options.generateSpecificImageForSceneId || `scene-${index}-${Date.now()}`;
     let footageUrl = '';
+    let footageType: 'image' | 'video' = 'image';
     let imageGenError: string | undefined = undefined;
 
     const duration = item.duration > 0 ? item.duration : calculateDurationFromText(item.sceneText);
@@ -120,11 +128,14 @@ export const processNarrationToScenes = async (
       const imagenResult = await generateImageWithImagen(item.imagePrompt, sceneId);
       if (imagenResult.base64Image) {
         footageUrl = imagenResult.base64Image;
+        footageType = 'image';
       } else {
         imageGenError = imagenResult.userFriendlyError || 'AI image generation failed. Using placeholder.';
         console.warn(imageGenError, "Prompt:", item.imagePrompt);
         onProgress(imageGenError, (index + 1) / scenesToProcess.length, 'ai_image', index + 1, scenesToProcess.length, imageGenError);
-        footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+        const placeholder = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+        footageUrl = placeholder.url;
+        footageType = placeholder.type;
       }
     } else {
       onProgress(
@@ -134,7 +145,9 @@ export const processNarrationToScenes = async (
         index + 1,
         scenesToProcess.length
       );
-      footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+      const placeholder = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+      footageUrl = placeholder.url;
+      footageType = placeholder.type;
     }
     
     const kenBurnsConfig = generateSceneKenBurnsConfig(validatedDuration);
@@ -143,6 +156,7 @@ export const processNarrationToScenes = async (
         const sceneToUpdateIndex = existingScenes.findIndex(s => s.id === options.generateSpecificImageForSceneId);
         if (sceneToUpdateIndex !== -1) {
             existingScenes[sceneToUpdateIndex].footageUrl = footageUrl;
+            existingScenes[sceneToUpdateIndex].footageType = footageType;
             existingScenes[sceneToUpdateIndex].kenBurnsConfig = kenBurnsConfig; // Re-gen KB if image changes
             // Optionally update keywords/imagePrompt if they were also re-analyzed
             existingScenes[sceneToUpdateIndex].imagePrompt = item.imagePrompt; 
@@ -164,6 +178,7 @@ export const processNarrationToScenes = async (
           imagePrompt: item.imagePrompt,
           duration: validatedDuration,
           footageUrl: footageUrl,
+          footageType: footageType,
           kenBurnsConfig: kenBurnsConfig,
         });
     }

--- a/types.ts
+++ b/types.ts
@@ -14,7 +14,8 @@ export interface Scene {
   keywords: string[];
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
-  footageUrl: string; // URL to image (can be base64 data URL)
+  footageUrl: string; // URL to image/video (can be base64 data URL)
+  footageType: 'image' | 'video';
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- fetch placeholder clips via Pexels video API
- track whether scenes use image or video footage
- render video clips in the preview player
- handle mixed media when generating final WebM
- mention Pexels videos in README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854407212e8832e89157bb6e705da4d