### PR TITLE
Add Pexels video placeholders

### DIFF
--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -112,12 +112,13 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 </p>
                 <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
                 <p className="text-gray-300 text-sm truncate">
-                    <strong className="text-gray-400">Image:</strong> {
-                        scene.footageUrl.startsWith('data:image') ? 
-                        (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 
-                        'Placeholder'
+                    <strong className="text-gray-400">Footage:</strong> {
+                        scene.footageType === 'video' ?
+                        'Video Placeholder' :
+                        (scene.footageUrl.startsWith('data:image') ?
+                          (useAiImagesGlobal ? 'AI Generated' : 'Custom Image Data') : 'Placeholder')
                     }
-                    {scene.footageUrl.startsWith('data:image') && scene.imagePrompt && 
+                    {scene.footageType === 'image' && scene.footageUrl.startsWith('data:image') && scene.imagePrompt &&
                      <span className="text-xs text-gray-500 italic ml-1">(Prompt: {scene.imagePrompt.substring(0,30)}...)</span>
                     }
                 </p>

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -293,13 +293,25 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
       <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
         {imageSlots.map((slot, index) => (
           slot.scene ? (
-            <img
-              key={`slot-${index}-${slot.scene.id}`}
-              src={slot.scene.footageUrl}
-              alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
-              style={getImageStyle(slot)}
-              loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
-            />
+            slot.scene.footageType === 'video' ? (
+              <video
+                key={`slot-${index}-${slot.scene.id}`}
+                src={slot.scene.footageUrl}
+                style={getImageStyle(slot)}
+                autoPlay
+                muted
+                loop
+                playsInline
+              />
+            ) : (
+              <img
+                key={`slot-${index}-${slot.scene.id}`}
+                src={slot.scene.footageUrl}
+                alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
+                style={getImageStyle(slot)}
+                loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
+              />
+            )
           ) : null
         ))}
         {currentScene && isPlaying && (

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -27,8 +27,9 @@ const generateSceneKenBurnsConfig = (duration: number): KenBurnsConfig => {
 export const fetchPlaceholderFootageUrl = async (
   keywords: string[],
   aspectRatio: AspectRatio,
+  duration?: number,
   sceneId?: string // Optional sceneId for more unique placeholders if needed
-): Promise<string> => {
+): Promise<{ url: string; type: 'video' | 'image' }> => {
   const width = aspectRatio === '16:9' ? 960 : 540; // smaller for faster downloads
   const height = aspectRatio === '16:9' ? 540 : 960;
 
@@ -41,28 +42,39 @@ export const fetchPlaceholderFootageUrl = async (
   if (PEXELS_API_KEY) {
     try {
       const resp = await fetch(
-        `https://api.pexels.com/v1/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
+        `https://api.pexels.com/videos/search?query=${encodeURIComponent(query)}&orientation=${orientation}&per_page=50`,
         { headers: { Authorization: PEXELS_API_KEY } }
       );
       if (resp.ok) {
         const data = await resp.json();
-        if (data.photos && data.photos.length > 0) {
-          const photo = data.photos[Math.floor(Math.random() * data.photos.length)];
-          const url = photo.src.large2x || photo.src.large || photo.src.original;
-          return `${url}?random_bust=${Date.now()}`;
+        if (data.videos && data.videos.length > 0) {
+          const filtered = data.videos.filter((v: any) =>
+            orientation === 'landscape' ? v.width >= v.height : v.height >= v.width
+          );
+          const videos = filtered.length > 0 ? filtered : data.videos;
+          let chosen = videos[0];
+          if (duration) {
+            chosen = videos.reduce((best: any, cur: any) =>
+              Math.abs(cur.duration - duration!) < Math.abs(best.duration - duration!) ? cur : best,
+            videos[0]);
+          }
+          const bestFile = chosen.video_files.sort((a: any, b: any) => b.width - a.width)[0];
+          if (bestFile && bestFile.link) {
+            return { url: `${bestFile.link}`, type: 'video' };
+          }
         }
       } else {
         console.warn(`Pexels API request failed with ${resp.status}`);
       }
     } catch (err) {
-      console.warn('Error fetching from Pexels API:', err);
+      console.warn('Error fetching from Pexels video API:', err);
     }
   } else {
     console.warn('PEXELS_API_KEY not set. Falling back to loremflickr.');
   }
 
   const encodedQuery = encodeURIComponent(query);
-  return `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`;
+  return { url: `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`, type: 'image' };
 };
 
 export interface ProcessNarrationOptions {
@@ -104,6 +116,7 @@ export const processNarrationToScenes = async (
     const item = scenesToProcess[index];
     const sceneId = options.generateSpecificImageForSceneId || `scene-${index}-${Date.now()}`;
     let footageUrl = '';
+    let footageType: 'image' | 'video' = 'image';
     let imageGenError: string | undefined = undefined;
 
     const duration = item.duration > 0 ? item.duration : calculateDurationFromText(item.sceneText);
@@ -120,11 +133,14 @@ export const processNarrationToScenes = async (
       const imagenResult = await generateImageWithImagen(item.imagePrompt, sceneId);
       if (imagenResult.base64Image) {
         footageUrl = imagenResult.base64Image;
+        footageType = 'image';
       } else {
         imageGenError = imagenResult.userFriendlyError || 'AI image generation failed. Using placeholder.';
         console.warn(imageGenError, "Prompt:", item.imagePrompt);
         onProgress(imageGenError, (index + 1) / scenesToProcess.length, 'ai_image', index + 1, scenesToProcess.length, imageGenError);
-        footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+        const placeholder = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, validatedDuration, sceneId);
+        footageUrl = placeholder.url;
+        footageType = placeholder.type;
       }
     } else {
       onProgress(
@@ -134,7 +150,9 @@ export const processNarrationToScenes = async (
         index + 1,
         scenesToProcess.length
       );
-      footageUrl = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, sceneId);
+      const placeholder = await fetchPlaceholderFootageUrl(item.keywords, aspectRatio, validatedDuration, sceneId);
+      footageUrl = placeholder.url;
+      footageType = placeholder.type;
     }
     
     const kenBurnsConfig = generateSceneKenBurnsConfig(validatedDuration);
@@ -143,6 +161,7 @@ export const processNarrationToScenes = async (
         const sceneToUpdateIndex = existingScenes.findIndex(s => s.id === options.generateSpecificImageForSceneId);
         if (sceneToUpdateIndex !== -1) {
             existingScenes[sceneToUpdateIndex].footageUrl = footageUrl;
+            existingScenes[sceneToUpdateIndex].footageType = footageType;
             existingScenes[sceneToUpdateIndex].kenBurnsConfig = kenBurnsConfig; // Re-gen KB if image changes
             // Optionally update keywords/imagePrompt if they were also re-analyzed
             existingScenes[sceneToUpdateIndex].imagePrompt = item.imagePrompt; 
@@ -164,6 +183,7 @@ export const processNarrationToScenes = async (
           imagePrompt: item.imagePrompt,
           duration: validatedDuration,
           footageUrl: footageUrl,
+          footageType: footageType,
           kenBurnsConfig: kenBurnsConfig,
         });
     }

--- a/types.ts
+++ b/types.ts
@@ -14,7 +14,8 @@ export interface Scene {
   keywords: string[];
   imagePrompt: string; // Added for AI image generation
   duration: number; // in seconds
-  footageUrl: string; // URL to image (can be base64 data URL)
+  footageUrl: string; // URL to image or video (can be base64 data URL)
+  footageType: 'image' | 'video';
   kenBurnsConfig: KenBurnsConfig;
 }
 


### PR DESCRIPTION
## Summary
- update `Scene` type with `footageType`
- fetch placeholder footage from Pexels video API
- render video elements in preview when needed
- mark placeholder type in scene editor
- adapt scene generation logic for new API and type

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854458c8088832e8544fc04fe038d4c