### PR TITLE
Switch placeholder videos to Wikimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Optionally add `PEXELS_API_KEY` for higher quality placeholder images. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Placeholder footage now comes from Wikimedia Commons, so no additional API keys are required. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/constants.ts
+++ b/constants.ts
@@ -15,7 +15,6 @@ export const IMAGEN_MODEL = 'imagen-3.0-generate-002';
 
 // Placeholder for API Key - this should be set in the environment
 export const API_KEY = process.env.API_KEY;
-export const PEXELS_API_KEY = process.env.PEXELS_API_KEY;
 // Optional URL where the main app is hosted. If set, the landing page
 // will redirect here when users click "Get Started".
 export const LAUNCH_URL = process.env.LAUNCH_URL;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,10 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
-      define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.PEXELS_API_KEY': JSON.stringify(env.PEXELS_API_KEY)
-      },
+        define: {
+          'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+          'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        },
       resolve: {
         alias: {
           '@': path.resolve(__dirname, '.'),


### PR DESCRIPTION
## Summary
- use Wikimedia Commons API for placeholder footage
- drop Pexels API usage and variable
- update README instructions about API keys

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685449c15710832ea07823777cbca9d6