### PR TITLE
Fix cross‑origin video preview

### DIFF
--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -298,6 +298,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
                 key={`slot-${index}-${slot.scene.id}`}
                 src={slot.scene.footageUrl}
                 style={getImageStyle(slot)}
+                crossOrigin="anonymous"
                 autoPlay
                 muted
                 loop
@@ -309,6 +310,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
                 src={slot.scene.footageUrl}
                 alt={`Footage for: ${slot.scene.keywords.join(', ')}`}
                 style={getImageStyle(slot)}
+                crossOrigin="anonymous"
                 loading={index === activeSlotIndex || index === (1-activeSlotIndex) ? "eager" : "lazy"}
               />
             )


### PR DESCRIPTION
## Summary
- ensure placeholder video and image elements request cross-origin resources correctly

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68544ecb4d70832eaaa93bf8cc468d94