### PR TITLE
Switch placeholders to Wikimedia videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Premium: AI‑generated imagery and TTS narration
 - Premium: One-click AI video generation
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
+- Placeholder footage is pulled as videos directly from Wikimedia Commons
 
 ## Getting Started
 
@@ -18,7 +19,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    ```bash
    npm install
    ```
-2. Create a `.env.local` file and set `GEMINI_API_KEY`. Placeholder footage now comes from Wikimedia Commons, so no additional API keys are required. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
+2. Create a `.env.local` file and set `GEMINI_API_KEY`. Placeholder footage now comes from Wikimedia Commons and is provided as video only, so no additional API keys are required. If the landing page should redirect to another domain when starting the app, set `LAUNCH_URL` to that URL.
 3. Start the development server
    ```bash
    npm run dev

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -68,7 +68,7 @@ export const fetchPlaceholderFootageUrl = async (
   duration?: number,
   sceneId?: string // Optional sceneId for more unique placeholders if needed
 ): Promise<{ url: string; type: 'video' | 'image' }> => {
-  const width = aspectRatio === '16:9' ? 960 : 540; // smaller for faster downloads
+  const width = aspectRatio === '16:9' ? 960 : 540; // used if fallback search needs orientation hints
   const height = aspectRatio === '16:9' ? 540 : 960;
 
   const query = (keywords && keywords.length > 0)
@@ -82,8 +82,9 @@ export const fetchPlaceholderFootageUrl = async (
     return { url: wikiVideo, type: 'video' };
   }
 
-  const encodedQuery = encodeURIComponent(query);
-  return { url: `https://loremflickr.com/${width}/${height}/${encodedQuery}?lock=${sceneId || Date.now()}`, type: 'image' };
+  // If no result for the specific query, attempt a generic stock search
+  const fallback = await fetchWikimediaVideo('stock footage', orientation, duration);
+  return { url: fallback || '', type: 'video' };
 };
 
 export interface ProcessNarrationOptions {


### PR DESCRIPTION
## Summary
- remove LoremFlickr image fallback
- fetch fallback videos from Wikimedia instead
- document that placeholders are videos from Wikimedia Commons

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68545004a740832e8101755cd4882a12