### PR TITLE
Fix repeating placeholder footage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Premium: AI‑generated imagery and TTS narration
 - Premium: One-click AI video generation
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
-- Placeholder footage is pulled as videos directly from Wikimedia Commons
+- Placeholder footage is pulled as videos directly from Wikimedia Commons, now
+  selected randomly from the best search results so each scene has different
+  footage when possible
 
 ## Getting Started
 

--- a/services/videoService.ts
+++ b/services/videoService.ts
@@ -46,15 +46,16 @@ const fetchWikimediaVideo = async (
       return orientation === 'landscape' ? info.width >= info.height : info.height >= info.width;
     });
     if (videos.length === 0) return null;
-    let best = videos[0];
     if (duration) {
-      best = videos.reduce((a, b) => {
+      videos.sort((a, b) => {
         const ad = Math.abs((a.imageinfo[0].duration || 0) - duration);
         const bd = Math.abs((b.imageinfo[0].duration || 0) - duration);
-        return bd < ad ? b : a;
-      }, best);
+        return ad - bd;
+      });
     }
-    return best.imageinfo[0].url as string;
+    const candidates = videos.slice(0, 5);
+    const choice = candidates[Math.floor(Math.random() * candidates.length)];
+    return choice.imageinfo[0].url as string;
   } catch (err) {
     console.warn('Error fetching from Wikimedia API:', err);
     return null;
@@ -122,9 +123,10 @@ export const processNarrationToScenes = async (
   }
 
 
+  const timestamp = Date.now();
   for (let index = 0; index < scenesToProcess.length; index++) {
     const item = scenesToProcess[index];
-    const sceneId = options.generateSpecificImageForSceneId || `scene-${index}-${Date.now()}`;
+    const sceneId = options.generateSpecificImageForSceneId || `scene-${index}-${timestamp}`;
     let footageUrl = '';
     let footageType: 'image' | 'video' = 'image';
     let imageGenError: string | undefined = undefined;


### PR DESCRIPTION
## Summary
- randomize which Wikimedia video is selected for placeholders
- use one timestamp for scene IDs to avoid collisions
- clarify that placeholders come from varied Wikimedia footage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854538fb680832eaf06ca1222272d78