### PR TITLE
Persist started state

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -5,13 +5,26 @@ import LandingPage from './components/LandingPage.tsx';
 import { LAUNCH_URL } from './constants.ts';
 
 const Root: React.FC = () => {
-  const [started, setStarted] = useState(false);
+  // Persist whether the user has launched the main app so refreshing the page
+  // doesn't send them back to the landing page.
+  const [started, setStarted] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('started') === 'true';
+    }
+    return false;
+  });
 
   const handleGetStarted = () => {
     if (LAUNCH_URL) {
       window.location.href = LAUNCH_URL;
     } else {
       setStarted(true);
+      try {
+        localStorage.setItem('started', 'true');
+      } catch (err) {
+        // Non-critical; if storage fails we simply won't persist state
+        console.warn('Unable to persist started state:', err);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- keep user on the app after clicking **Get Started** by saving state in localStorage

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545f87018c832e91fff633082504e2