### PR TITLE
Persist started flag

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,7 +17,9 @@ import { SparklesIcon } from './components/IconComponents.tsx';
 
 const premiumUser = IS_PREMIUM_USER;
 
-const App: React.FC = () => {
+interface AppProps { onBackToLanding?: () => void; }
+
+const App: React.FC<AppProps> = ({ onBackToLanding }) => {
   const [narrationText, setNarrationText] = useState<string>('');
   const [scenes, setScenes] = useState<Scene[]>([]);
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>(DEFAULT_ASPECT_RATIO);
@@ -393,6 +395,14 @@ const App: React.FC = () => {
         <p className="mt-2 text-base sm:text-lg text-gray-400">
           Transform text into videos with AI-powered visuals and spoken narration.
         </p>
+        {onBackToLanding && (
+          <button
+            onClick={onBackToLanding}
+            className="mt-4 text-sm text-fuchsia-400 hover:underline"
+          >
+            Back to Landing Page
+          </button>
+        )}
       </header>
 
       {apiKeyMissing && (

--- a/index.tsx
+++ b/index.tsx
@@ -1,11 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import LandingPage from './components/LandingPage.tsx';
 import { LAUNCH_URL } from './constants.ts';
 
 const Root: React.FC = () => {
-  const [started, setStarted] = useState(false);
+  const [started, setStarted] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('cinesynth-started') === 'true';
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('cinesynth-started', started ? 'true' : 'false');
+    }
+  }, [started]);
 
   const handleGetStarted = () => {
     if (LAUNCH_URL) {
@@ -15,7 +26,15 @@ const Root: React.FC = () => {
     }
   };
 
-  return started ? <App /> : <LandingPage onGetStarted={handleGetStarted} />;
+  const handleBackToLanding = () => {
+    setStarted(false);
+  };
+
+  return started ? (
+    <App onBackToLanding={handleBackToLanding} />
+  ) : (
+    <LandingPage onGetStarted={handleGetStarted} />
+  );
 };
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
## Summary
- keep app active after clicking **Get Started** by storing a flag in `localStorage`
- allow returning to landing page from within the app

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68546073ac34832eaf65867883957fd0