### PR TITLE
Fix Safari recording issue

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -239,15 +239,17 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
         }
       );
 
-      setProgressMessage('Converting to MP4...');
-      const mp4Blob = await convertWebMToMP4(webmBlob, (convProg) => {
-        setProgressMessage(`Converting to MP4: ${Math.round(convProg * 100)}%`);
-        setProgressValue(100 - Math.round((1 - convProg) * 5));
-      });
+      let finalBlob = webmBlob;
+      if (!webmBlob.type.includes('mp4')) {
+        setProgressMessage('Converting to MP4...');
+        finalBlob = await convertWebMToMP4(webmBlob, (convProg) => {
+          setProgressMessage(`Converting to MP4: ${Math.round(convProg * 100)}%`);
+          setProgressValue(100 - Math.round((1 - convProg) * 5));
+        });
+        console.log('MP4 conversion complete. Blob size:', finalBlob.size, 'bytes');
+      }
 
-      console.log('MP4 conversion complete. Blob size:', mp4Blob.size, 'bytes');
-
-      const url = URL.createObjectURL(mp4Blob);
+      const url = URL.createObjectURL(finalBlob);
       const a = document.createElement('a');
       a.href = url;
       a.download = `cinesynth_video_${Date.now()}.mp4`;

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Premium: AI‑generated imagery and TTS narration
 - Premium: One-click AI video generation
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
+- Safari users record directly to MP4 when possible to avoid conversion delays
 - Placeholder footage is pulled as videos directly from Wikimedia Commons, now
   selected randomly from the best search results so each scene has different
   footage when possible


### PR DESCRIPTION
## Summary
- improve MIME type detection for MediaRecorder with MP4 fallback
- skip MP4 conversion when recording already uses MP4
- note Safari MP4 recording in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68546a2dacc8832eb2ac5cc802572d64