### PR TITLE
Fix Safari recording issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Premium: AI‑generated imagery and TTS narration
 - Premium: One-click AI video generation
 - Browser-based WebM to MP4 conversion via ffmpeg.wasm
+- Safari users record directly to MP4 when possible to avoid conversion delays
+- Cross-origin isolation is only required when ffmpeg.wasm runs for WebM\u2192MP4 conversion
 - Placeholder footage is pulled as videos directly from Wikimedia Commons, now
   selected randomly from the best search results so each scene has different
   footage when possible


### PR DESCRIPTION
## Summary
- improve MIME type detection for MediaRecorder with MP4 fallback
- skip MP4 conversion when recording already uses MP4
- note Safari MP4 recording in README
- defer cross-origin isolation requirement until conversion

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68546a2dacc8832eb2ac5cc802572d64