### PR TITLE
Improve download speed and narration splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
 - Automatic editing and subtitle generation
 - Premium: AI‑generated imagery and TTS narration
 - Premium: One-click AI video generation
-- Browser-based WebM to MP4 conversion via ffmpeg.wasm
+- Browser-based WebM download, no MP4 conversion needed
 - Placeholder footage is pulled as videos directly from Wikimedia Commons, now
   selected randomly from the best search results so each scene has different
   footage when possible
@@ -27,15 +27,15 @@ CineSynth transforms text scripts into marketing-ready videos in minutes. Powere
    npm run dev
    ```
 
-Development mode automatically provides the required cross-origin isolation headers so ffmpeg.wasm can use `SharedArrayBuffer`. Always run the app via `npm run dev` or `npm run preview` after building.
+Development mode automatically provided cross-origin isolation headers for the previous MP4 conversion step. Since downloads are now WebM-only, this is no longer required, but running with `npm run dev` or `npm run preview` is still recommended.
 
-### Faster MP4 Conversion
+### Download Format
 
-By default the browser-based conversion uses the `ultrafast` preset for speed. Edit `services/mp4ConversionService.ts` if you prefer higher quality.
+The generated video downloads directly as WebM. If you need MP4, you can still convert manually using `services/mp4ConversionService.ts` and ffmpeg.wasm.
 
 ## Deployment
 
-When deploying to Vercel, create a `vercel.json` file so each request includes the cross-origin headers needed by ffmpeg.wasm:
+If you plan to enable MP4 conversion via ffmpeg.wasm, create a `vercel.json` file so each request includes the cross-origin headers required by ffmpeg:
 
 ```json
 {
@@ -51,7 +51,7 @@ When deploying to Vercel, create a `vercel.json` file so each request includes t
 }
 ```
 
-This ensures the MP4 conversion works correctly in the hosted app.
+These headers were previously required for MP4 conversion. They can be omitted if you only use WebM downloads.
 
 If the landing page is served separately from the full editor, provide the
 target URL in a `LAUNCH_URL` environment variable. Visitors clicking

--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -357,7 +357,7 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           aria-live="polite"
         >
           <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />
-          {isDownloading ? 'Rendering Video...' : 'Download Video'}
+          {isDownloading ? 'Rendering Video...' : 'Download WebM'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch video downloads to WebM instead of converting to MP4
- update button text and README to reflect WebM download flow
- enhance Gemini prompt to encourage more scenes
- add simple fallback segmentation when AI returns only one scene

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854e721607c832e86bdcc87aea2cb21