### PR TITLE
Improve placeholder media relevance

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -326,7 +326,16 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
 
   const handleAddScene = async () => {
     const newSceneId = `scene-new-${Date.now()}`;
-    const placeholder = await fetchPlaceholderFootageUrl(["new scene", "abstract"], aspectRatio, 5, newSceneId);
+    const placeholder = await fetchPlaceholderFootageUrl(
+      {
+        keywords: ["new scene", "abstract"],
+        sceneText: "New scene text...",
+        imagePrompt: "Abstract background for a new scene"
+      },
+      aspectRatio,
+      5,
+      newSceneId
+    );
     const newScene: Scene = {
       id: newSceneId,
       sceneText: "New scene text...",
@@ -361,14 +370,32 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
                 sceneToUpdate.footageType = 'image';
             } else {
                 addWarning(result.userFriendlyError || `AI image failed for scene ${sceneId}. Using new placeholder.`);
-                const placeholder = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneToUpdate.duration, sceneId + "-retry");
+                const placeholder = await fetchPlaceholderFootageUrl(
+                  {
+                    keywords: sceneToUpdate.keywords,
+                    sceneText: sceneToUpdate.sceneText,
+                    imagePrompt: sceneToUpdate.imagePrompt
+                  },
+                  aspectRatio,
+                  sceneToUpdate.duration,
+                  sceneId + "-retry"
+                );
                 newFootageUrl = placeholder.url;
                 sceneToUpdate.footageType = placeholder.type;
                 errorOccurred = true;
             }
         } else {
             setProgressValue(30);
-            const placeholder = await fetchPlaceholderFootageUrl(sceneToUpdate.keywords, aspectRatio, sceneToUpdate.duration, sceneId + "-refresh");
+            const placeholder = await fetchPlaceholderFootageUrl(
+              {
+                keywords: sceneToUpdate.keywords,
+                sceneText: sceneToUpdate.sceneText,
+                imagePrompt: sceneToUpdate.imagePrompt
+              },
+              aspectRatio,
+              sceneToUpdate.duration,
+              sceneId + "-refresh"
+            );
             newFootageUrl = placeholder.url;
             sceneToUpdate.footageType = placeholder.type;
         }


### PR DESCRIPTION
## Summary
- replace the placeholder search logic with contextual query generation and relevance scoring so Wikimedia results better match each scene
- allow the placeholder fetcher to fall back to meaningful images and return videos or photos depending on the best match
- update scene management code to provide full context (keywords, text, image prompts) when requesting placeholder media

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdea5b0ae0832ea3a85687181c1b95