### PR TITLE
Support MP4 fallback for preview rendering

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -148,7 +148,7 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
     setProgressValue(0);
 
     try {
-      const webmBlob = await generateWebMFromScenes(
+      const generatedVideo = await generateWebMFromScenes(
         scenesToRender,
         ratio,
         { includeWatermark },
@@ -167,15 +167,15 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
         return null;
       }
 
-      let previewBlob: Blob = webmBlob;
-      let previewFormat: 'webm' | 'mp4' = 'webm';
+      let previewBlob: Blob = generatedVideo.blob;
+      let previewFormat: 'webm' | 'mp4' = generatedVideo.format;
 
-      if (!browserSupportsWebM) {
+      if (previewFormat === 'webm' && !browserSupportsWebM) {
         const canAttemptConversion = typeof window !== 'undefined' && window.crossOriginIsolated;
         if (canAttemptConversion) {
           setProgressMessage('Converting preview to MP4 for playback...');
           try {
-            const mp4Blob = await convertWebMToMP4(webmBlob, (convProg) => {
+            const mp4Blob = await convertWebMToMP4(generatedVideo.blob, (convProg) => {
               if (previewRenderTokenRef.current !== token) {
                 return;
               }
@@ -203,7 +203,7 @@ const App: React.FC<AppProps> = ({ onBackToLanding }) => {
       }
 
       updatePreviewVideo(previewBlob, previewFormat);
-      setProgressMessage('Preview video ready!');
+      setProgressMessage(`${previewFormat.toUpperCase()} preview ready!`);
       setProgressValue(100);
 
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- expose generated video metadata from the rendering service so callers know the container format
- allow the MediaRecorder pipeline to pick MP4 when WebM codecs are unsupported and return blob/mime info
- update the preview workflow to respect the reported format and skip redundant conversion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5b6a0f40832e87a47ae06ad6887c