### PR TITLE
Autoplay generated preview video

### DIFF
--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -278,12 +278,16 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
         <div className={`relative w-full ${footageAspectRatioClass} bg-black overflow-hidden rounded-md`}>
           <video
             key={videoUrl}
-            src={videoUrl}
             controls
             playsInline
             loop
+            autoPlay
+            muted
             className="w-full h-full rounded-md"
-          />
+          >
+            <source src={videoUrl} type={`video/${videoFormat}`} />
+            Your browser does not support the video tag.
+          </video>
           {isPreparingVideoFile && (
             <div className="absolute inset-0 bg-black/60 flex items-center justify-center text-white text-sm sm:text-base">
               Updating preview video...


### PR DESCRIPTION
## Summary
- ensure the generated preview video element autoplays and is muted for browser compliance
- provide an explicit source element with the correct mime type so browsers can start playback immediately

## Testing
- npm run build *(fails: Rollup failed to resolve import "webm-muxer" from services/videoRenderingService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ce5f0f6860832e896ec6543ae9ada0