### PR TITLE
Optimize preview and download rendering pipeline

### DIFF
--- a/components/VideoPreview.tsx
+++ b/components/VideoPreview.tsx
@@ -21,6 +21,8 @@ interface VideoPreviewProps {
   isGenerating: boolean;
   isDownloading?: boolean;
   isPreparingVideoFile?: boolean;
+  isPreparingDownload?: boolean;
+  isDownloadReady?: boolean;
   isTTSEnabled: boolean;
   onTTSPlay: (text: string) => void;
   onTTSPause: () => void;
@@ -29,6 +31,7 @@ interface VideoPreviewProps {
   ttsPlaybackStatus: 'idle' | 'playing' | 'paused' | 'ended';
   videoUrl?: string | null;
   videoFormat?: 'webm' | 'mp4';
+  downloadFormat?: 'webm' | 'mp4';
 }
 
 const getDefaultSlotState = (): ImageSlotState => ({
@@ -47,6 +50,8 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   isGenerating,
   isDownloading,
   isPreparingVideoFile = false,
+  isPreparingDownload = false,
+  isDownloadReady = false,
   isTTSEnabled,
   onTTSPlay,
   onTTSPause,
@@ -54,7 +59,8 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   onTTSStop,
   ttsPlaybackStatus,
   videoUrl,
-  videoFormat = 'webm'
+  videoFormat = 'webm',
+  downloadFormat = videoFormat,
 }) => {
   const [currentSceneIndex, setCurrentSceneIndex] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -271,6 +277,17 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
   };
 
   const footageAspectRatioClass = aspectRatio === '16:9' ? 'aspect-video' : 'aspect-[9/16]';
+  const previewFormatLabel = videoFormat?.toUpperCase() ?? 'VIDEO';
+  const resolvedDownloadFormatLabel = (downloadFormat ?? videoFormat ?? 'video').toUpperCase();
+  const downloadButtonText = (() => {
+    if (isDownloading) return 'Rendering video...';
+    if (isPreparingVideoFile) return `Updating ${previewFormatLabel} preview...`;
+    if (isPreparingDownload && !isDownloadReady) return 'Preparing HD download...';
+    if (isPreparingDownload && isDownloadReady) return `Refreshing ${resolvedDownloadFormatLabel} download...`;
+    if (isDownloadReady) return `Download ${resolvedDownloadFormatLabel}`;
+    return `Download ${previewFormatLabel}`;
+  })();
+  const isDownloadButtonBusy = isPreparingVideoFile || isPreparingDownload;
 
   if (videoUrl) {
     return (
@@ -296,23 +313,29 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
         </div>
         <div className="mt-3 flex items-center justify-between space-x-2">
           <div className="text-xs sm:text-sm text-gray-400 uppercase tracking-wide">
-            {videoFormat?.toUpperCase()} preview ready
+            {previewFormatLabel} preview ready
           </div>
           <button
             onClick={onDownloadRequest}
             disabled={isDownloading || isGenerating}
             className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-white hover:bg-gray-200 disabled:opacity-50 text-black text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
             aria-live="polite"
-            aria-busy={isPreparingVideoFile || undefined}
+            aria-busy={isDownloadButtonBusy || undefined}
           >
             <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />
-            {isDownloading
-              ? 'Rendering Video...'
-              : isPreparingVideoFile
-                ? `Queueing ${videoFormat?.toUpperCase() ?? 'VIDEO'} Download...`
-                : `Download ${videoFormat?.toUpperCase() ?? 'VIDEO'}`}
+            {downloadButtonText}
           </button>
         </div>
+        {isPreparingDownload && !isDownloadReady && (
+          <p className="mt-2 text-[10px] sm:text-xs text-gray-400">
+            Preparing a high-quality download in the background...
+          </p>
+        )}
+        {isDownloadReady && downloadFormat && (
+          <p className="mt-2 text-[10px] sm:text-xs text-gray-400">
+            Download ready as {resolvedDownloadFormatLabel}.
+          </p>
+        )}
       </div>
     );
   }
@@ -418,18 +441,24 @@ const VideoPreview: React.FC<VideoPreviewProps> = ({
           disabled={scenes.length === 0 || isGenerating || isDownloading}
           className="flex items-center px-3 py-2 sm:px-4 sm:py-2.5 bg-white hover:bg-gray-200 disabled:opacity-50 text-black text-xs sm:text-sm font-medium rounded-md shadow-sm transition-colors"
           aria-live="polite"
-          aria-busy={isPreparingVideoFile || undefined}
+          aria-busy={isDownloadButtonBusy || undefined}
         >
           <DownloadIcon className="w-4 h-4 sm:w-5 sm:h-5 mr-1 sm:mr-2" />
-          {isDownloading
-            ? 'Rendering Video...'
-            : isPreparingVideoFile
-              ? 'Queueing Download...'
-              : 'Download Video'}
+          {downloadButtonText}
         </button>
       </div>
+      {isPreparingDownload && !isDownloadReady && (
+        <div className="mt-2 text-xs sm:text-sm text-gray-400 text-right">
+          Preparing a high-quality download in the background...
+        </div>
+      )}
       {isPreparingVideoFile && (
         <div className="mt-2 text-xs sm:text-sm text-gray-400 text-right">Rendering preview video file...</div>
+      )}
+      {isDownloadReady && downloadFormat && (
+        <div className="mt-1 text-xs sm:text-sm text-gray-400 text-right">
+          Download ready as {resolvedDownloadFormatLabel}.
+        </div>
       )}
     </div>
   );

--- a/services/mp4ConversionService.ts
+++ b/services/mp4ConversionService.ts
@@ -1,29 +1,70 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile } from '@ffmpeg/util';
 
+let ffmpegInstance: FFmpeg | null = null;
+let ffmpegLoadingPromise: Promise<void> | null = null;
+
+const getFFmpegInstance = async (): Promise<FFmpeg> => {
+  if (!ffmpegInstance) {
+    ffmpegInstance = new FFmpeg();
+  }
+
+  if (!ffmpegInstance.loaded) {
+    ffmpegLoadingPromise = ffmpegLoadingPromise ?? ffmpegInstance.load();
+    await ffmpegLoadingPromise;
+    ffmpegLoadingPromise = null;
+  }
+
+  return ffmpegInstance;
+};
+
 export const convertWebMToMP4 = async (
   webmBlob: Blob,
   onProgress?: (progress: number) => void
 ): Promise<Blob> => {
-  const ffmpeg = new FFmpeg();
-  ffmpeg.on('progress', ({ progress }) => {
-    if (onProgress) onProgress(Math.min(1, progress));
-  });
-  if (!ffmpeg.loaded) {
-    await ffmpeg.load();
+  const ffmpeg = await getFFmpegInstance();
+  const inputFileName = `input_${Date.now()}.webm`;
+  const outputFileName = `output_${Date.now()}.mp4`;
+
+  const handleProgress = ({ progress }: { progress: number }) => {
+    if (onProgress) {
+      onProgress(Math.min(1, progress));
+    }
+  };
+
+  if (onProgress) {
+    ffmpeg.on('progress', handleProgress);
   }
-  await ffmpeg.writeFile('input.webm', await fetchFile(webmBlob));
-  await ffmpeg.exec([
-    '-i',
-    'input.webm',
-    '-c:v',
-    'libx264',
-    '-preset',
-    'ultrafast',
-    '-pix_fmt',
-    'yuv420p',
-    'output.mp4',
-  ]);
-  const data = await ffmpeg.readFile('output.mp4');
-  return new Blob([data], { type: 'video/mp4' });
+
+  try {
+    await ffmpeg.writeFile(inputFileName, await fetchFile(webmBlob));
+    await ffmpeg.exec([
+      '-y',
+      '-i',
+      inputFileName,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'ultrafast',
+      '-pix_fmt',
+      'yuv420p',
+      outputFileName,
+    ]);
+    const data = await ffmpeg.readFile(outputFileName);
+    return new Blob([data], { type: 'video/mp4' });
+  } finally {
+    if (onProgress && typeof (ffmpeg as any).off === 'function') {
+      (ffmpeg as any).off('progress', handleProgress);
+    }
+    try {
+      await (ffmpeg as any).deleteFile?.(inputFileName);
+    } catch (error) {
+      console.warn('Failed to delete temporary input file after conversion.', error);
+    }
+    try {
+      await (ffmpeg as any).deleteFile?.(outputFileName);
+    } catch (error) {
+      console.warn('Failed to delete temporary output file after conversion.', error);
+    }
+  }
 };


### PR DESCRIPTION
## Summary
- add dedicated preview and download render states so high-quality exports are prepared in the background and cached for reuse
- update the client preview to surface download readiness, background preparation, and re-render triggers when scenes change
- tune the rendering service with preview/download specific configs and reuse an ffmpeg instance for faster MP4 conversion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce62b33980832ea0d4e31b3a6f589b