### PR TITLE
Optimize video rendering to output MP4 directly via WebCodecs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ffmpeg/util": "^0.12.2",
         "@google/genai": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "mp4-muxer": "^5.2.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "webm-muxer": "^3.2.1"
@@ -1701,6 +1702,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mp4-muxer": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/mp4-muxer/-/mp4-muxer-5.2.2.tgz",
+      "integrity": "sha512-dhozjTywI0h2qFzeShagt8YYw811fh1XlwiDCE2f6Aeqf6xG2CyuShoSa5E0AZDO8pPF0JOZ3wOmWBNWIGdSpQ==",
+      "deprecated": "This library is superseded by Mediabunny. Please migrate to it.",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "^0.1.6",
+        "@types/wicg-file-system-access": "^2020.9.5"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ffmpeg/util": "^0.12.2",
     "@google/genai": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "mp4-muxer": "^5.2.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "webm-muxer": "^3.2.1"


### PR DESCRIPTION
## Summary
- add mp4-muxer so the WebCodecs renderer can mux H.264 output directly in the browser
- upgrade the WebCodecs rendering path to choose an MP4 pipeline for downloads and fall back to VP9/WebM when needed
- keep the MediaRecorder fallback but reuse the new helpers, enabling MP4 downloads without the slow ffmpeg wasm conversion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce836c2e38832eba3010ec1a237338