### PR TITLE
Enhance scene pacing and visual overlays

### DIFF
--- a/components/SceneEditor.tsx
+++ b/components/SceneEditor.tsx
@@ -82,8 +82,12 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                     id={`sceneDuration-${scene.id}`}
                     type="number"
                     value={editDuration}
-                    onChange={(e) => setEditDuration(Math.max(1, parseInt(e.target.value, 10) || 1))}
+                    onChange={(e) => {
+                      const parsed = parseFloat(e.target.value);
+                      setEditDuration(Math.max(1, Number.isFinite(parsed) ? parsed : 1));
+                    }}
                     min="1"
+                    step="0.1"
                     className="w-full p-2 bg-neutral-900 border border-neutral-700 rounded-md text-gray-200 focus:ring-white focus:border-white"
                     disabled={isGenerating}
                   />
@@ -110,7 +114,7 @@ const SceneEditor: React.FC<SceneEditorProps> = ({
                 <p className="text-gray-300 text-sm whitespace-pre-wrap break-words">
                   <strong className="text-gray-400">Text:</strong> {scene.sceneText.length > 100 ? scene.sceneText.substring(0,97) + "..." : scene.sceneText}
                 </p>
-                <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration}s</p>
+                <p className="text-gray-300 text-sm"><strong className="text-gray-400">Duration:</strong> {scene.duration.toFixed(1)}s</p>
                 <p className="text-gray-300 text-sm truncate">
                     <strong className="text-gray-400">Footage:</strong> {
                         scene.footageType === 'video' ?

--- a/constants.ts
+++ b/constants.ts
@@ -1,9 +1,9 @@
 
 export const APP_TITLE = "CineSynth";
 export const DEFAULT_ASPECT_RATIO = '16:9';
-export const AVERAGE_WORDS_PER_SECOND = 3; // Fallback if Gemini doesn't provide duration
+export const AVERAGE_WORDS_PER_SECOND = 2.4; // Fallback if Gemini doesn't provide duration
 export const MAX_SCENE_DURATION_SECONDS = 15; // Encourage dynamic pacing
-export const MIN_SCENE_DURATION_SECONDS = 4;
+export const MIN_SCENE_DURATION_SECONDS = 3;
 
 export const FALLBACK_FOOTAGE_KEYWORDS = [
   "abstract", "cityscape", "nature", "technology", "office", "landscape", "motion graphics"

--- a/services/renderTiming.ts
+++ b/services/renderTiming.ts
@@ -135,12 +135,17 @@ export const buildRenderPlan = (
   const effectiveDurations = computeEffectiveDurations(scenes, mode);
 
   return scenes.map((scene, index) => {
-    const durationSeconds = effectiveDurations[index] ?? 0;
-    const frameCount = Math.max(1, Math.round(durationSeconds * fps));
+    const durationSecondsRaw = effectiveDurations[index] ?? 0;
+    const safeDurationSeconds = durationSecondsRaw > 0.01
+      ? durationSecondsRaw
+      : mode === 'preview'
+        ? PREVIEW_MIN_SCENE_DURATION_SECONDS
+        : Math.max(1.2, 1 / fps);
+    const frameCount = Math.max(1, Math.ceil(safeDurationSeconds * fps));
 
     return {
       scene,
-      durationSeconds,
+      durationSeconds: safeDurationSeconds,
       frameCount,
     };
   });


### PR DESCRIPTION
## Summary
- Refine narration timing heuristics to better match script pacing and lower the minimum scene length
- Render dynamic subtitle overlays with accent colors and generate stylized fallback imagery when footage fails
- Allow fractional scene durations in the editor and adjust frame planning so rendered videos honor updated timings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce8a0ae79c832e83fae2dcca93f66f